### PR TITLE
Fix version file

### DIFF
--- a/configure
+++ b/configure
@@ -12875,7 +12875,7 @@ unset program_transform_name
 #--------------------------------------------------------------------
 # Set version file
 VERSIONTXT="./Driver/etc/version"
-if test -d .git; then
+if test -d .git || test -f .git; then
     which git 1>/dev/null 2>/dev/null
     if test $? -eq 0; then
         VERSION=`git log --date=short --pretty=format:"Last Commit Day:%ad, Hash Value:%h" -1`

--- a/configure.in
+++ b/configure.in
@@ -2140,7 +2140,7 @@ unset program_transform_name
 #--------------------------------------------------------------------
 # Set version file
 VERSIONTXT="./Driver/etc/version"
-if test -d .git; then
+if test -f .git; then
     which git 1>/dev/null 2>/dev/null
     if test $? -eq 0; then
         VERSION=`git log --date=short --pretty=format:"Last Commit Day:%ad, Hash Value:%h" -1`

--- a/configure.in
+++ b/configure.in
@@ -2140,7 +2140,7 @@ unset program_transform_name
 #--------------------------------------------------------------------
 # Set version file
 VERSIONTXT="./Driver/etc/version"
-if test -f .git; then
+if test -d .git || test -f .git; then
     which git 1>/dev/null 2>/dev/null
     if test $? -eq 0; then
         VERSION=`git log --date=short --pretty=format:"Last Commit Day:%ad, Hash Value:%h" -1`


### PR DESCRIPTION
We are using omni-compiler as a git submodule and building it directly from `cmake` with the `ExternalProject` definition. 

In this configuration, the `.git` directory is in fact a file and the `version` file generation will fail in that case. 

Changing the test resolve this problem and I think does not prevent the original behavior to work.  