### PR TITLE
Byacc/Yacc fix

### DIFF
--- a/C-FrontEnd/src/Makefile.in
+++ b/C-FrontEnd/src/Makefile.in
@@ -33,7 +33,7 @@ c-parser.output: c-parser.h
 c-parser.h: c-parser.y c-parser.c
 	/bin/bash ../.././buildutils/ylwrap c-parser.y y.tab.c c-parser.c y.tab.h \
 	`echo c-parser.c | sed -e s/cc$$/hh/ -e s/cpp$$/hpp/ -e s/cxx$$/hxx/ -e s/c++$$/h++/ -e s/c$$/h/` \
-	y.output c-parser.output -- byacc -v -d
+	y.output c-parser.output -- ${YACC} -v -d
 
 .c.o: 
 	$(CC) $(CFLAGS) $< -c


### PR DESCRIPTION
I have notice that you are using `byacc` in one `Makefile.in`. I changed it to use the `YACC` variable defined in the `configure` script. In some of your supercomputers, we do not have `byacc` so I don't know if it make sense to use `yacc` instead in those cases.   