### PR TITLE
Support the omp barrier directive & the omp num_threads clause in C decompiler

### DIFF
--- a/C-BackEnd/src/xcodeml/c/util/XmcXcodeToXcTranslator.java
+++ b/C-BackEnd/src/xcodeml/c/util/XmcXcodeToXcTranslator.java
@@ -1768,6 +1768,9 @@ public class XmcXcodeToXcTranslator {
 
 	    obj.setLine("#pragma omp " + dirName);
 
+            if (dirName.equals("barrier"))
+		return;
+
             if (dirName.equals("threadprivate")){
 		obj.addToken("(");
             	

--- a/C-BackEnd/src/xcodeml/c/util/XmcXcodeToXcTranslator.java
+++ b/C-BackEnd/src/xcodeml/c/util/XmcXcodeToXcTranslator.java
@@ -1818,6 +1818,7 @@ public class XmcXcodeToXcTranslator {
                 else if (clauseName.equals("dir_if"))                clauseName = "if";
                 else if (clauseName.equals("dir_nowait"))            clauseName = "nowait";
                 else if (clauseName.equals("dir_schedule"))          clauseName = "schedule";
+                else if (clauseName.equals("dir_num_threads"))       clauseName = "num_threads";
             
 		obj.addToken(clauseName);
                 
@@ -1826,13 +1827,19 @@ public class XmcXcodeToXcTranslator {
 		    obj.addToken("(");
 		    if (operator != "") obj.addToken(operator + " :");
 
-		    if (!arg.getNodeName().equals("list")){ // default clause
-		      String kind = XmDomUtil.getContentText(arg).toLowerCase();
-		      if (kind.equals("default_shared")) kind = "shared";
-		      else if (kind.equals("default_none")) kind = "none";
-		      obj.addToken(kind);
-		    }
-		    else {
+            if (!arg.getNodeName().equals("list")){
+                String text = XmDomUtil.getContentText(arg);
+                if (clauseName.equals("if") || clauseName.equals("num_threads"))
+                    obj.addToken(text);
+                else
+                {   // 'default' clause
+                    String kind = text.toLowerCase();
+                    if (kind.equals("default_shared")) kind = "shared";
+                    else if (kind.equals("default_none")) kind = "none";
+                    obj.addToken(kind);
+                }
+            }
+            else {
 		      NodeList varList = arg.getChildNodes();
 
 		      String kind = XmDomUtil.getContentText(varList.item(0)).toLowerCase();

--- a/XcodeML-Exc-Tools/src/exc/xcodeml/XmcXobjectToXcodeTranslator.java
+++ b/XcodeML-Exc-Tools/src/exc/xcodeml/XmcXobjectToXcodeTranslator.java
@@ -1045,6 +1045,10 @@ public class XmcXobjectToXcodeTranslator extends XmXobjectToXcodeTranslator {
             }
             addChildNode(e, f1);
 
+            // barrier directive
+            if (xobj.Nargs() < 3)
+                break;
+
             Element f2 = createElement("list");
             Xobject body = xobj.getArg(2);
             if (body != null){


### PR DESCRIPTION
These commits support the code like below in C-BackEnd.
```c
#include <stdio.h>

void f(int aBc)
{
#pragma omp parallel num_threads(aBc)
    {
        int tnum = omp_get_thread_num();

        printf("[%d]\n", tnum);

#pragma omp barrier

        for (int i = 0; i < 10; i++)
            printf("%d:%d\n", tnum, i);
    }
}

int main () {
    f(4);
    return 0;
}
```
