### PR TITLE
Fix bugs of the type-bound procedure

### DIFF
--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -4889,10 +4889,6 @@ compile_type_bound_procedure(expr x)
                     error_at_node(x, "NOPASS is already specified.");
                     return;
                 }
-                if (binding_attr_flags & TYPE_BOUND_PROCEDURE_PASS) {
-                    error_at_node(x, "PASS and NO_PASS conflicts.");
-                    return;
-                }
                 binding_attr_flags |= TYPE_BOUND_PROCEDURE_NOPASS;
                 break;
             case F03_NON_OVERRIDEABLE_SPEC:
@@ -4900,6 +4896,7 @@ compile_type_bound_procedure(expr x)
                     error_at_node(x, "NON_OVERRIDABLE is already specified.");
                     return;
                 }
+                warning_at_node(x, "NOT IMPLEMENTED YET\n");
                 binding_attr_flags |= TYPE_BOUND_PROCEDURE_NON_OVERRIDABLE;
                 break;
             case F03_DEFERRED_SPEC:
@@ -4922,10 +4919,6 @@ compile_type_bound_procedure(expr x)
                     error_at_node(x, "PUBLIC is already specified.");
                     return;
                 }
-                if (access_attr_flags & (TYPE_ATTR_PRIVATE)) {
-                    error_at_node(x, "access specs are conflicted.");
-                    return;
-                }
                 access_attr_flags |= TYPE_ATTR_PUBLIC;
                 break;
             case F95_PRIVATE_SPEC:
@@ -4945,6 +4938,23 @@ compile_type_bound_procedure(expr x)
         }
     }
 
+    if ((binding_attr_flags & TYPE_BOUND_PROCEDURE_PASS) &&
+        (binding_attr_flags & TYPE_BOUND_PROCEDURE_NOPASS)) {
+        error_at_node(x, "PASS and NO_PASS conflicts.");
+        return;
+    }
+
+    if ((binding_attr_flags & TYPE_BOUND_PROCEDURE_DEFERRED) &&
+        (binding_attr_flags & TYPE_BOUND_PROCEDURE_NON_OVERRIDABLE)) {
+        error_at_node(x, "DEFERRED and NON_OVERRIDABLE conflicts.");
+        return;
+    }
+
+    if ((access_attr_flags & (TYPE_ATTR_PRIVATE)) &&
+        (access_attr_flags & (TYPE_ATTR_PUBLIC))) {
+        error_at_node(x, "access specs are conflicted.");
+        return;
+    }
 
     if (!(binding_attr_flags & TYPE_BOUND_PROCEDURE_NOPASS)) {
         /* set a default attribute */
@@ -4953,6 +4963,10 @@ compile_type_bound_procedure(expr x)
 
     if (interface_name) {
         interface = new_ident_desc(EXPR_SYM(interface_name));
+        if (!(binding_attr_flags & TYPE_BOUND_PROCEDURE_DEFERRED)) {
+            error_at_node(x, "require DEFERRED attribute");
+        }
+        warning_at_node(x, "NOT IMPLEMENTED YET\n");
         FOR_ITEMS_IN_LIST(lp, bindings) {
             if (EXPR_CODE(LIST_ITEM(lp)) != IDENT) {
                 error_at_node(x, "unexpected expression");

--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -3419,17 +3419,22 @@ compile_type_bound_procedure_call(expv memberRef, expr args) {
         ID bindto;
         FOREACH_ID(bind, TYPE_BOUND_GENERIC_TYPE_GENERICS(ftp)) {
             bindto = find_struct_member_allow_private(stp, ID_SYM(bind), TRUE);
-            if (function_type_is_appliable(ID_TYPE(bindto), a)) {
-                ftp = ID_TYPE(bindto);
-                EXPV_TYPE(memberRef) = ftp;
+            if (TYPE_REF(ID_TYPE(bindto)) &&
+                function_type_is_appliable(TYPE_REF(ID_TYPE(bindto)), a)) {
+                ftp = TYPE_REF(ID_TYPE(bindto));
+                /* EXPV_TYPE(memberRef) = ftp; */
             }
         }
 
         if (ftp) {
             ret_type = FUNCTION_TYPE_RETURN_TYPE(ftp);
-        } else {
-            error("There is no appliable type-bound procedure");
         }
+        else {
+            if (debug_flag)
+                fprintf(debug_fp, "There is no appliable type-bound procedure");
+        }
+        /* type-bound generic procedure type does not exist in XcodeML */
+        EXPV_TYPE(memberRef) = NULL;
     } else {
         // for type-bound PROCEDURE
         if (ftp != NULL) {
@@ -3438,7 +3443,15 @@ compile_type_bound_procedure_call(expv memberRef, expr args) {
                 error("argument type mismatch");
             }
 #endif
-            ret_type = FUNCTION_TYPE_RETURN_TYPE(ftp);
+            if (TYPE_REF(ftp)) {
+                ret_type = FUNCTION_TYPE_RETURN_TYPE(TYPE_REF(ftp));
+            } else {
+                /*
+                 * type-bound procedure is not bound yet,
+                 * so set a dummy type.
+                 */
+                ret_type = FUNCTION_TYPE_RETURN_TYPE(ftp);
+            }
         }
     }
 

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -1824,7 +1824,17 @@ update_type_bound_procedures(TYPE_DESC struct_decls, ID ids)
                             SYM_NAME(ID_SYM(mem)));
                 }
                 TYPE_REF(ID_TYPE(mem)) = ID_TYPE(target);
-                if (IS_SUBR(ID_TYPE(target))) {
+                if (IS_FUNCTION_TYPE(ID_TYPE(target))) {
+                    /*
+                     * update the dummy return type
+                     */
+                    TYPE_DESC ret;
+                    TYPE_DESC dummy_ret;
+                    ret = FUNCTION_TYPE_RETURN_TYPE(ID_TYPE(target));
+                    dummy_ret = FUNCTION_TYPE_RETURN_TYPE(ID_TYPE(mem));
+                    TYPE_BASIC_TYPE(dummy_ret) = TYPE_BASIC_TYPE(ret);
+                    TYPE_REF(dummy_ret) = ret;
+                } else { /* IS_SUBR(ID_TYPE(target) == TRUE */
                     TYPE_BASIC_TYPE(ID_TYPE(mem)) = TYPE_SUBR;
                 }
             }
@@ -5023,12 +5033,11 @@ compile_CALL_type_bound_procedure_statement(expr x)
             }
         }
         if (tp == NULL) {
-            /*
-             * if not found, raise error
-             */
-            error("invalid argument for type-bound generic");
-            tp = ID_TYPE(TBP_BINDING(tpd));
+            if (debug_flag)
+                fprintf(debug_fp, "invalid argument for type-bound generic");
         }
+        /* type-bound generic procedure type does not exist in XcodeML */
+        tp = NULL;
     }
 
     v = list2(FUNCTION_CALL,

--- a/F-FrontEnd/src/F-datatype.c
+++ b/F-FrontEnd/src/F-datatype.c
@@ -197,10 +197,11 @@ program_type(void)
 TYPE_DESC
 type_bound_procedure_type(void)
 {
+    TYPE_DESC ret; /* dummy return type */
     TYPE_DESC tp;
-    tp = new_type_desc();
-    TYPE_BASIC_TYPE(tp) = TYPE_FUNCTION;
-    FUNCTION_TYPE_SET_FUNCTION(tp);
+    ret = new_type_desc();
+    TYPE_BASIC_TYPE(ret) = TYPE_GENERIC;
+    tp = function_type(ret);
     FUNCTION_TYPE_SET_TYPE_BOUND(tp);
     return tp;
 }

--- a/F-FrontEnd/src/F-ident.c
+++ b/F-FrontEnd/src/F-ident.c
@@ -49,7 +49,7 @@ find_ext_id_head(SYMBOL s, EXT_ID head)
 {
     EXT_ID ep;
     FOREACH_EXT_ID(ep, head) {
-        if(strcmp(SYM_NAME(EXT_SYM(ep)), SYM_NAME(s)) == 0)
+        if(EXT_SYM(ep) && strcmp(SYM_NAME(EXT_SYM(ep)), SYM_NAME(s)) == 0)
             return ep;
     }
     return NULL;

--- a/F-FrontEnd/test/testdata/type_bound_procedure_3.f90
+++ b/F-FrontEnd/test/testdata/type_bound_procedure_3.f90
@@ -4,7 +4,6 @@
          CONTAINS
            PROCEDURE, PUBLIC :: f
            PROCEDURE, PUBLIC :: g => f, h => f
-           PROCEDURE(f), PUBLIC :: i, j
         END TYPE t
       CONTAINS
         FUNCTION f(this, w) RESULT(ans)

--- a/F-FrontEnd/test/testdata/type_bound_procedure_3.f90
+++ b/F-FrontEnd/test/testdata/type_bound_procedure_3.f90
@@ -18,4 +18,7 @@
 
       PROGRAM main
         USE m
+        INTEGER :: a
+        TYPE(t) :: v = t(1)
+        a = v%f(1)
       END PROGRAM main

--- a/F-FrontEnd/test/testdata/type_bound_procedure_generic.f90
+++ b/F-FrontEnd/test/testdata/type_bound_procedure_generic.f90
@@ -27,3 +27,15 @@
         END FUNCTION equals_t_int
 
       END MODULE m
+
+      PROGRAM main
+        USE m
+        TYPE(t) :: o1
+        o1 = 10
+        IF (o1==10) THEN
+          PRINT *,'OK'
+        ELSE
+          PRINT *,'NG'
+        END IF
+      END PROGRAM main
+


### PR DESCRIPTION
Fix bugs:
 - fail if the type-bound procedure call appears before the procedure to bind appears
 - fail if the type-bound generic call appears before the type-bound procedure is bound

And:
 - add a warning for the DEFERRED type-bound procedure
 - add a warning for the NON_OVRRIDEABLE type-bound procedure