### PR TITLE
Pointer assignment to a subarray

### DIFF
--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -2144,8 +2144,9 @@ outx_pointerAssignStatement(int l, expv v)
     vPointee = EXPR_ARG2(v);
 
     if (EXPV_CODE(vPointer) != F_VAR &&
+        EXPV_CODE(vPointer) != ARRAY_REF &&
         EXPV_CODE(vPointer) != F95_MEMBER_REF) {
-        fatal("%s: Invalid argument, expected F_VAR or F95_MEMBER_REF.", __func__);
+        fatal("%s: Invalid argument, expected F_VAR or F_ARRAY_REF or F95_MEMBER_REF.", __func__);
     }
     if (EXPV_CODE(vPointee) != F_VAR &&
         EXPV_CODE(vPointee) != ARRAY_REF &&

--- a/F-FrontEnd/test/testdata/pointer_assignment_with_lower_bound.f90
+++ b/F-FrontEnd/test/testdata/pointer_assignment_with_lower_bound.f90
@@ -1,0 +1,5 @@
+      PROGRAM main
+        REAL,TARGET  :: x(-100:100,-10:10)
+        REAL,POINTER :: p(:,:)
+        p(1:,1:) => x
+      END PROGRAM main


### PR DESCRIPTION
This pull-request enable the pointer assignment to a subarray.

ex)
```fortran
   p(1:,1:) => x
```