### PR TITLE
Allocatable character

### DIFF
--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -2436,9 +2436,11 @@ compile_basic_type(expr x)
     if(rcharLen) {
         if((vcharLen = compile_expression(rcharLen)) == NULL)
             return NULL;
-        if(EXPV_CODE(vcharLen) == F_ASTERISK)
+        if (EXPV_CODE(vcharLen) == F_ASTERISK) {
             charLen = CHAR_LEN_UNFIXED;
-        else {
+        } else if (EXPV_CODE(vcharLen) == F08_LEN_SPEC_COLON) {
+            charLen = CHAR_LEN_ALLOCATABLE;
+        } else {
             if((vcharLen1 = expv_reduce(vcharLen, TRUE)) == NULL) {
                 charLen = CHAR_LEN_UNFIXED;
             } else {

--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -2389,11 +2389,11 @@ compile_basic_type(expr x)
     if(rkind) {
         /*
          * FIXME:
-         *	SUPER BOGUS FLAG ALERT !
+         *  SUPER BOGUS FLAG ALERT !
          */
         is_in_kind_compilation_flag_for_declare_ident = TRUE;
-	//org_vkind = vkind = compile_expression(rkind);
-	vkind = compile_expression(rkind);
+        //org_vkind = vkind = compile_expression(rkind);
+        vkind = compile_expression(rkind);
         is_in_kind_compilation_flag_for_declare_ident = FALSE;
 
         if(vkind == NULL)  return NULL;

--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -885,8 +885,11 @@ compile_expression(expr x)
 
         case F95_LEN_SELECTOR_SPEC: {
             expv v;
-            if(EXPR_ARG1(x) == NULL)
+            if (EXPR_ARG1(x) == NULL)
                 return expv_any_term(F_ASTERISK, NULL);
+            if (EXPR_CODE(EXPR_ARG1(x)) == F08_LEN_SPEC_COLON)
+                return expv_any_term(F08_LEN_SPEC_COLON, NULL);
+
             v = compile_expression(EXPR_ARG1(x));
             if((v = expv_reduce(v, FALSE)) == NULL) return NULL;
             /* if type is not fixed yet, do implicit declaration here */

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -2483,8 +2483,9 @@ end_declaration()
             if (TYPE_IS_ALLOCATABLE(tp) &&
                 !(IS_ARRAY_TYPE(tp) ||
                   TYPE_IS_COINDEXED(tp) ||
-                  TYPE_IS_CLASS(tp))) {
-                error_at_id(ip, "ALLOCATABLE is applied only to array/coarray/class");
+                  TYPE_IS_CLASS(tp) ||
+                  (IS_CHAR(tp) && IS_CHAR_LEN_ALLOCATABLE(tp)))) {
+                error_at_id(ip, "ALLOCATABLE is applied only to array/coarray/class/character(:)");
             } else if (TYPE_IS_OPTIONAL(tp) && !(ID_IS_DUMMY_ARG(ip))) {
                 warning_at_id(ip, "OPTIONAL is applied only "
                               "to dummy argument");

--- a/F-FrontEnd/src/F-datatype.c
+++ b/F-FrontEnd/src/F-datatype.c
@@ -31,7 +31,7 @@ type_char(int len)
     /* (len <=0) means character(len=*) in function argument */
     tp = new_type_desc();
     TYPE_BASIC_TYPE(tp) = TYPE_CHAR;
-    assert(len >= 0 || len == CHAR_LEN_UNFIXED);
+    assert(len >= 0 || len == CHAR_LEN_UNFIXED || len == CHAR_LEN_ALLOCATABLE);
     TYPE_CHAR_LEN(tp) = len;
     return tp;
 }

--- a/F-FrontEnd/src/F-datatype.h
+++ b/F-FrontEnd/src/F-datatype.h
@@ -402,6 +402,8 @@ extern TYPE_DESC basic_type_desc[];
 
 #define CHAR_LEN_UNFIXED (-1)
 
+#define CHAR_LEN_ALLOCATABLE (-2)
+
 /* macros distinguishing type */
 #define IS_STRUCT_TYPE(tp) \
                 ((tp) != NULL && TYPE_BASIC_TYPE(tp) == TYPE_STRUCT)
@@ -440,6 +442,8 @@ extern TYPE_DESC basic_type_desc[];
                 ((tp) != NULL && (TYPE_BASIC_TYPE(tp) == TYPE_CHAR))
 #define IS_CHAR_LEN_UNFIXED(tp) \
                 ((tp) != NULL && (TYPE_CHAR_LEN(tp) == CHAR_LEN_UNFIXED))
+#define IS_CHAR_LEN_ALLOCATABLE(tp) \
+                ((tp) != NULL && (TYPE_CHAR_LEN(tp) == CHAR_LEN_ALLOCATABLE))
 #define IS_LOGICAL(tp) \
                 ((tp) != NULL && (TYPE_BASIC_TYPE(tp) == TYPE_LOGICAL))
 #define IS_INT_CONST_V(v) \

--- a/F-FrontEnd/src/F-input-xmod.c
+++ b/F-FrontEnd/src/F-input-xmod.c
@@ -1124,12 +1124,21 @@ static int
 input_len(xmlTextReaderPtr reader, HashTable * ht, TYPE_DESC tp)
 {
     expv v = NULL;
+    char * is_assumed_size;
+    char * is_assumed_shape;
 
     if (!xmlMatchNode(reader, XML_READER_TYPE_ELEMENT, "len"))
         return TRUE;
 
-    if (!xmlSkipWhiteSpace(reader)) 
+    if (!xmlSkipWhiteSpace(reader))
         return FALSE;
+
+    is_assumed_size = (char *) xmlTextReaderGetAttribute(reader,
+                                   BAD_CAST "is_assumed_size");
+
+    is_assumed_shape = (char *) xmlTextReaderGetAttribute(reader,
+                                    BAD_CAST "is_assumed_shape");
+
 
     if (xmlMatchNode(reader, XML_READER_TYPE_END_ELEMENT, "len")) {
         /* if <len> tag is empty, size is unfixed */
@@ -1140,6 +1149,14 @@ input_len(xmlTextReaderPtr reader, HashTable * ht, TYPE_DESC tp)
 
         if (v != NULL)
             TYPE_LENG(tp) = v;
+    }
+
+    if (is_assumed_size != NULL) {
+        TYPE_CHAR_LEN(tp) = CHAR_LEN_UNFIXED;
+        free(is_assumed_size);
+    } else if (is_assumed_shape != NULL) {
+        TYPE_CHAR_LEN(tp) = CHAR_LEN_ALLOCATABLE;
+        free(is_assumed_shape);
     }
 
     if (!xmlExpectNode(reader, XML_READER_TYPE_END_ELEMENT, "len"))

--- a/F-FrontEnd/src/F-input-xmod.c
+++ b/F-FrontEnd/src/F-input-xmod.c
@@ -1674,7 +1674,9 @@ input_FbasicType(xmlTextReaderPtr reader, HashTable * ht)
         if (EXPR_CODE(TYPE_LENG(tp)) == INT_CONSTANT) {
             TYPE_CHAR_LEN(tp) = EXPV_INT_VALUE(TYPE_LENG(tp));
         } else {
-            /* don't use as Fcharacter */
+            /*
+             * don't use as a character basictype "Fcharacter"
+             */
             TYPE_CHAR_LEN(tp) = 0;
         }
     }
@@ -1706,10 +1708,11 @@ input_FbasicType(xmlTextReaderPtr reader, HashTable * ht)
         free(typeId);
 
     /*
-     * cut last
+     * Remove a character basic type which is genereted from 'ref="Fcharacter"'
      */
     if (IS_CHAR(tp))  {
-        if (TYPE_REF(TYPE_REF(tp)) == NULL && TYPE_CHAR_LEN(TYPE_REF(tp)) == 1) {
+        if (TYPE_REF(TYPE_REF(tp)) == NULL &&
+            TYPE_CHAR_LEN(TYPE_REF(tp)) == 1) {
             TYPE_REF(tp) = NULL;
         }
     }

--- a/F-FrontEnd/src/F-input-xmod.c
+++ b/F-FrontEnd/src/F-input-xmod.c
@@ -1642,6 +1642,11 @@ input_FbasicType(xmlTextReaderPtr reader, HashTable * ht)
         TYPE_REF(tp) = getTypeDesc(ht, ref);
         TYPE_BASIC_TYPE(tp) = TYPE_BASIC_TYPE(TYPE_REF(tp));
         shrink_type(tp);
+
+        if (IS_CHAR(tp))  {
+            TYPE_CHAR_LEN(tp) = TYPE_CHAR_LEN(TYPE_REF(tp));
+        }
+
     } else {
         TYPE_REF(tp) = NULL;
         if (TYPE_IS_PROCEDURE(tp)) {
@@ -1651,7 +1656,7 @@ input_FbasicType(xmlTextReaderPtr reader, HashTable * ht)
         }
     }
 
-    if (!xmlSkipWhiteSpace(reader)) 
+    if (!xmlSkipWhiteSpace(reader))
         return FALSE;
 
     if (isEmpty)
@@ -1664,6 +1669,15 @@ input_FbasicType(xmlTextReaderPtr reader, HashTable * ht)
     /* <len> */
     if (!input_len(reader, ht, tp))
         return FALSE;
+
+    if (IS_CHAR(tp) && TYPE_LENG(tp))  {
+        if (EXPR_CODE(TYPE_LENG(tp)) == INT_CONSTANT) {
+            TYPE_CHAR_LEN(tp) = EXPV_INT_VALUE(TYPE_LENG(tp));
+        } else {
+            /* don't use as Fcharacter */
+            TYPE_CHAR_LEN(tp) = 0;
+        }
+    }
 
     /* <indexRange> */
     while (xmlMatchNode(reader, XML_READER_TYPE_ELEMENT, "indexRange")) {
@@ -1690,6 +1704,15 @@ input_FbasicType(xmlTextReaderPtr reader, HashTable * ht)
 
     if (typeId != NULL)
         free(typeId);
+
+    /*
+     * cut last
+     */
+    if (IS_CHAR(tp))  {
+        if (TYPE_REF(TYPE_REF(tp)) == NULL && TYPE_CHAR_LEN(TYPE_REF(tp)) == 1) {
+            TYPE_REF(tp) = NULL;
+        }
+    }
 
     return TRUE;
 }

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -5210,9 +5210,6 @@ outx_blockDataDefinition(int l, EXT_ID ep)
 }
 
 
-
-
-
 static const char*
 getTimestamp()
 {
@@ -5221,8 +5218,6 @@ getTimestamp()
     strftime(s_timestamp, CEXPR_OPTVAL_CHARLEN, "%F %T", ltm);
     return s_timestamp;
 }
-
-
 
 
 /**

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -4028,12 +4028,20 @@ outx_characterType(int l, TYPE_DESC tp)
         outx_kind(l1, tp);
 
         if(charLen != 1|| vcharLen != NULL) {
-            outx_tag(l1, "len");
-            if(IS_CHAR_LEN_UNFIXED(tp) == FALSE) {
+            if (!IS_CHAR_LEN_UNFIXED(tp) && !IS_CHAR_LEN_ALLOCATABLE(tp)) {
+                outx_tag(l1, "len");
                 if(vcharLen != NULL)
                     outx_expv(l2, vcharLen);
                 else
                     outx_intAsConst(l2, TYPE_CHAR_LEN(tp));
+            } else if (IS_CHAR_LEN_UNFIXED(tp)) {
+                outx_printi(l1, "<len");
+                outx_true(TRUE, "is_assumed_size");
+                outx_print(">\n");
+            } else if (IS_CHAR_LEN_ALLOCATABLE(tp)) {
+                outx_printi(l1, "<len");
+                outx_true(TRUE, "is_assumed_shape");
+                outx_print(">\n");
             }
             outx_close(l1, "len");
         }

--- a/F-FrontEnd/src/F95-parser.y
+++ b/F-FrontEnd/src/F95-parser.y
@@ -1254,7 +1254,7 @@ len_key_spec: KW_LEN '=' expr
 len_spec: '*'
         { $$ = list1(F95_LEN_SELECTOR_SPEC, NULL); }
         | ':'
-        { $$ = list1(F95_LEN_SELECTOR_SPEC, NULL); }
+        { $$ = list1(F95_LEN_SELECTOR_SPEC, list0(F08_LEN_SPEC_COLON)); }
         | expr
         { $$ = list1(F95_LEN_SELECTOR_SPEC, $1); }
         ;

--- a/F-FrontEnd/src/F95-parser.y
+++ b/F-FrontEnd/src/F95-parser.y
@@ -1253,6 +1253,8 @@ len_key_spec: KW_LEN '=' expr
 
 len_spec: '*'
         { $$ = list1(F95_LEN_SELECTOR_SPEC, NULL); }
+        | ':'
+        { $$ = list1(F95_LEN_SELECTOR_SPEC, NULL); }
         | expr
         { $$ = list1(F95_LEN_SELECTOR_SPEC, $1); }
         ;

--- a/F-FrontEnd/test/testdata/allocatable_character.f90
+++ b/F-FrontEnd/test/testdata/allocatable_character.f90
@@ -1,0 +1,7 @@
+      MODULE m
+        CHARACTER(len=:), ALLOCATABLE :: c
+      END MODULE m
+
+      PROGRAM main
+        USE m
+      END PROGRAM main

--- a/F-FrontEnd/test/testdata/assign_to_allocatable_character.f90
+++ b/F-FrontEnd/test/testdata/assign_to_allocatable_character.f90
@@ -1,0 +1,6 @@
+      character(:),allocatable:: name
+      name = 'John'
+      print *,len(name)
+      name = 'Tommy'
+      print *,len(name)
+      end

--- a/F-FrontEnd/test/testdata/assign_to_allocatable_integer_array.f90
+++ b/F-FrontEnd/test/testdata/assign_to_allocatable_integer_array.f90
@@ -1,0 +1,3 @@
+      INTEGER, DIMENSION(:),ALLOCATABLE:: i
+      i = (/1,2,3/)
+      end

--- a/F-FrontEnd/test/testdata/procedure_declaration_in_block.f90
+++ b/F-FrontEnd/test/testdata/procedure_declaration_in_block.f90
@@ -1,0 +1,10 @@
+      PROGRAM main
+        BLOCK
+          PROCEDURE(f), POINTER :: p
+        END BLOCK
+       CONTAINS
+        FUNCTION f(a)
+          INTEGER :: f
+          INTEGER :: a
+        END FUNCTION f
+      END PROGRAM main


### PR DESCRIPTION
This pull-request enable the allocatable character,

ex)
```
    CHARACTER(len=:), ALLOCATABLE :: c
```

and contains bugfix (missing the character length of the character which is imported from xmod)