### PR TITLE
Fix bug of the procedure variable imported from other module

### DIFF
--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -4299,7 +4299,7 @@ deep_ref_copy_for_module_id_type(TYPE_DESC tp) {
         FOREACH_MEMBER(id, cur) {
             ID new_id = new_ident_desc(ID_SYM(id));
             *new_id = *id;
-            deep_copy_and_overwrite_for_module_id_type(&(ID_TYPE(id)));
+            deep_copy_and_overwrite_for_module_id_type(&(ID_TYPE(new_id)));
             ID_LINK_ADD(new_id, new_members, last_ip);
         }
         TYPE_MEMBER_LIST(cur) = new_members;


### PR DESCRIPTION
This pull request will fix the bug of the procedure variable imported from other module.

ex)

This code failed in the backend.

```fortran
module m
   procedure, pointer(f) :: p
contains
   function f(a)
   end function f
end module m

program main
   use m
end program main
```