### PR TITLE
Fix for public/private in the derived-type declaration

### DIFF
--- a/F-BackEnd/src/xcodeml/f/decompile/XfDecompileDomVisitor.java
+++ b/F-BackEnd/src/xcodeml/f/decompile/XfDecompileDomVisitor.java
@@ -131,8 +131,8 @@ public class XfDecompileDomVisitor {
 
         XmfWriter writer = _context.getWriter();
 
-        /* public, private are allowed only in module definition */
-        if (_isUnderModuleDef()) {
+        /* public, private are allowed only in module definition OR in derived-type definition */
+        if (_isUnderModuleDef() || _isUnderFstructType()) {
             for (Node basicTypeNode : basicTypeNodeArray) {
                 if (XmDomUtil.getAttrBool(basicTypeNode, "is_public")) {
                     writer.writeToken(", ");
@@ -861,6 +861,10 @@ public class XfDecompileDomVisitor {
      */
     private boolean _isUnderModuleDef() {
         return _isInvokeNodeOf("FmoduleDefinition", 2);
+    }
+
+    private boolean _isUnderFstructType() {
+        return _isInvokeAncestorNodeOf("FstructDecl");
     }
 
     /**
@@ -4966,8 +4970,6 @@ public class XfDecompileDomVisitor {
                     writer.writeToken("BIND( " + bind.toUpperCase() + " )");
                 }
             }
-
-
 
             writer.writeToken(" :: ");
             writer.writeToken(structTypeName);

--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -2024,12 +2024,6 @@ declare_type_attributes(ID id, TYPE_DESC tp, expr attributes,
             TYPE_UNSET_PUBLIC(tp);
             TYPE_UNSET_PROTECTED(tp);
             TYPE_SET_PRIVATE(tp);
-#if 0
-            if (CTL_TYPE(ctl_top) == CTL_STRUCT) {
-                TYPE_DESC struct_tp = CTL_STRUCT_TYPEDESC(ctl_top);
-                TYPE_SET_INTERNAL_PRIVATE(struct_tp);
-            }
-#endif
             break;
         case F03_PROTECTED_SPEC:
             if (TYPE_IS_PUBLIC(tp)) {

--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -2024,10 +2024,12 @@ declare_type_attributes(ID id, TYPE_DESC tp, expr attributes,
             TYPE_UNSET_PUBLIC(tp);
             TYPE_UNSET_PROTECTED(tp);
             TYPE_SET_PRIVATE(tp);
+#if 0
             if (CTL_TYPE(ctl_top) == CTL_STRUCT) {
                 TYPE_DESC struct_tp = CTL_STRUCT_TYPEDESC(ctl_top);
                 TYPE_SET_INTERNAL_PRIVATE(struct_tp);
             }
+#endif
             break;
         case F03_PROTECTED_SPEC:
             if (TYPE_IS_PUBLIC(tp)) {
@@ -3926,6 +3928,57 @@ compile_struct_decl_end()
 
     /* check for type bound generic */
     check_type_bound_generics(stp);
+
+    if (!TYPE_IS_INTERNAL_PRIVATE(stp)) {
+        /*
+         * To transform the fortran code.
+         *
+         * TYPE t
+         *  INTEGER, PRIVATE :: a
+         *  INTEGER :: b
+         * END TYPE t
+         *
+         * will turn into
+         *
+         * TYPE t
+         *  PRIVATE
+         *  INTEGER :: a
+         *  INTEGER, PUBLIC :: b
+         * END TYPE t
+         *
+         */
+
+        ID mem;
+        int has_private_member = FALSE;
+
+        FOREACH_MEMBER(mem, stp) {
+            if (TYPE_IS_PRIVATE(ID_TYPE(mem))) {
+                has_private_member = TRUE;
+                break;
+            }
+        }
+
+        if (has_private_member) {
+            /*
+             * If the derived-type has a PRIVATE member,
+             * set is_internal_private to the derived-type.
+             */
+            TYPE_SET_INTERNAL_PRIVATE(stp);
+
+            /*
+             * Remove PRIVATE from PRIVATE members,
+             * and add PUBLIC to other members.
+             */
+            FOREACH_MEMBER(mem, stp) {
+                if (TYPE_IS_PRIVATE(ID_TYPE(mem))) {
+                    TYPE_UNSET_PRIVATE(ID_TYPE(mem));
+                } else {
+                    TYPE_SET_PUBLIC(ID_TYPE(mem));
+                }
+            }
+        }
+    }
+
 
     pop_ctl();
 }

--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -2651,8 +2651,10 @@ compile_struct_constructor_components(ID struct_id, expr args, expv components)
         }
 
         if (is_use_associated && ID_TYPE(match) != NULL &&
-            (TYPE_IS_INTERNAL_PRIVATE(match) ||
-             TYPE_IS_INTERNAL_PRIVATE(ID_TYPE(match)))) {
+            ((TYPE_IS_INTERNAL_PRIVATE(match) ||
+              TYPE_IS_INTERNAL_PRIVATE(ID_TYPE(match))) &&
+             !(TYPE_IS_PUBLIC(match) ||
+               TYPE_IS_PUBLIC(ID_TYPE(match))))) {
             error("accessing a private component");
             return FALSE;
         }

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -4300,6 +4300,17 @@ deep_ref_copy_for_module_id_type(TYPE_DESC tp) {
             ID new_id = new_ident_desc(ID_SYM(id));
             *new_id = *id;
             deep_copy_and_overwrite_for_module_id_type(&(ID_TYPE(new_id)));
+
+            /*
+             * PUBLIC/PRIVATE should be inherited
+             */
+            if (TYPE_IS_PUBLIC(ID_TYPE(id))) {
+                TYPE_SET_PUBLIC(ID_TYPE(new_id));
+            }
+            if (TYPE_IS_PRIVATE(ID_TYPE(id))) {
+                TYPE_SET_PRIVATE(ID_TYPE(new_id));
+            }
+
             ID_LINK_ADD(new_id, new_members, last_ip);
         }
         TYPE_MEMBER_LIST(cur) = new_members;

--- a/F-FrontEnd/test/failtestdata/derived_type_and_override_private_member.f90
+++ b/F-FrontEnd/test/failtestdata/derived_type_and_override_private_member.f90
@@ -1,11 +1,18 @@
-      MODULE m
+      MODULE m_dtpfe
         TYPE t
            INTEGER, PRIVATE :: a
            INTEGER :: b
         END TYPE t
         TYPE(t) :: v0 = t(a=1, b=2)
         TYPE(t) :: v1 = t(1, 2)
-      END MODULE m
+      END MODULE m_dtpfe
 
       PROGRAM MAIN
+        USE m_dtpfe
+
+        TYPE,EXTENDS(t) :: tt
+           INTEGER :: a
+        END type TT
+
+        v0%b = 1
       END PROGRAM MAIN

--- a/F-FrontEnd/test/testdata/derived_type_private_and_public.f90
+++ b/F-FrontEnd/test/testdata/derived_type_private_and_public.f90
@@ -1,0 +1,15 @@
+      MODULE m_dtpp
+        TYPE t
+           PRIVATE
+           INTEGER :: a = 3
+           INTEGER, PUBLIC :: b
+        END TYPE t
+        TYPE(t) :: v0 = t(a=1, b=2)
+        TYPE(t) :: v1 = t(1, 2)
+      END MODULE m_dtpp
+
+      PROGRAM MAIN
+        USE m_dtpp
+        TYPE(t) :: v2 = t(b=2)
+        v0%b = 1
+      END PROGRAM MAIN

--- a/F-FrontEnd/test/testdata/derived_type_private_for_submodule.f90
+++ b/F-FrontEnd/test/testdata/derived_type_private_for_submodule.f90
@@ -1,0 +1,30 @@
+      MODULE m_dtpfs
+        TYPE t
+           INTEGER, PRIVATE :: a
+           INTEGER :: b
+        END TYPE t
+        TYPE(t) :: v0 = t(a=1, b=2)
+        TYPE(t) :: v1 = t(1, 2)
+
+        INTERFACE
+           MODULE FUNCTION f(a)
+             INTEGER :: f
+             INTEGER :: a
+           END FUNCTION
+        END INTERFACE
+      END MODULE m_dtpfs
+
+      SUBMODULE(m_dtpfs) sub
+        TYPE(t) :: v2 = t(1,2)
+      CONTAINS
+        MODULE FUNCTION f(a)
+          INTEGER :: f
+          INTEGER :: a
+          f = v0%a + a
+        END FUNCTION
+      END SUBMODULE sub
+
+      PROGRAM MAIN
+        USE m_dtpfs
+        v0%b = 1
+      END PROGRAM MAIN

--- a/F-FrontEnd/test/testdata/derived_type_private_member.f90
+++ b/F-FrontEnd/test/testdata/derived_type_private_member.f90
@@ -1,0 +1,13 @@
+      MODULE m_dtpm
+        TYPE t
+           INTEGER, PRIVATE :: a
+           INTEGER :: b
+        END TYPE t
+        TYPE(t) :: v0 = t(a=1, b=2)
+        TYPE(t) :: v1 = t(1, 2)
+      END MODULE m_dtpm
+
+      PROGRAM MAIN
+        USE m_dtpm
+        v0%b = 1
+      END PROGRAM MAIN


### PR DESCRIPTION
This pull-request will fix the bug of public/private in the derived-type declaration.

The previous build remove the public attribute of members of the derived-type.

```fortran
    TYPE t
        PRIVATE
        INTEGER :: v
        INTEGER,PUBLIC :: u
    END TYPE t
```
This code was translated like:

```fortran
    TYPE t
        PRIVATE
        INTEGER :: v
        INTEGER :: u
    END TYPE t
```

So this pull-request will output the public attribute if the member has it.
