### PR TITLE
Fix bug of the procedure pointer assignment

### DIFF
--- a/F-FrontEnd/src/F-datatype.c
+++ b/F-FrontEnd/src/F-datatype.c
@@ -1249,8 +1249,10 @@ function_type_is_compatible0(const TYPE_DESC ftp1, const TYPE_DESC ftp2,
                     SYM_NAME(ID_SYM(arg1)), SYM_NAME(ID_SYM(arg2)));
         }
 
-        if (ID_SYM(arg1) != ID_SYM(arg2)) {
-            return FALSE;
+        if (override) {
+            if (ID_SYM(arg1) != ID_SYM(arg2)) {
+                return FALSE;
+            }
         }
 
         if (override || assignment) {


### PR DESCRIPTION
This pull requet will fix the bug of the procedure pointer assignment.

ex)
```fortran
    INTERFACE
      FUNCTION f(a)
         INTEGER :: f ,a
      END FUNCTION f
      FUNCTION g(b)
         INTEGER :: g, b
      END FUNCTION g
    END INTERFACE
    PROCEDURE(f), POINTER :: p
    p => g ! failed here
```

The previous build fail at the pointer assignment to the procedure pointer.
It is because that the argument name is different between `f` and `g`.
But actually the above code is valid.
