### PR TITLE
Add checking to the type parameter

### DIFF
--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -3494,10 +3494,22 @@ compile_type_decl(expr typeExpr, TYPE_DESC baseTp,
             }
 
             id = find_ident_from_type_parameter(EXPR_SYM(ident), struct_tp);
-            if (id != NULL && CURRENT_STATE != IN_TYPE_PARAM_DECL) {
-                error_at_node(decl_list, "'%s' is already used as a type parameter.", ID_NAME(id));
-                continue;
+            if (hasTypeParamAttr) {
+                if (id == NULL) {
+                    error_at_node(decl_list,
+                                  "'%s' is not in the type parameter.",
+                                  SYM_NAME(EXPR_SYM(ident)));
+                } else if (ID_TYPE(id) != NULL) {
+                    error_at_node(decl_list, "'%s' is already declared.",
+                                  ID_NAME(id));
+                }
+            } else {
+                if (id != NULL && CURRENT_STATE != IN_TYPE_PARAM_DECL) {
+                    error_at_node(decl_list, "'%s' is already used as a type parameter.", ID_NAME(id));
+                    continue;
+                }
             }
+
 
             id = declare_ident(EXPR_SYM(ident), CL_UNKNOWN);
             if (id == NULL) {

--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -2699,7 +2699,6 @@ expv
 compile_struct_constructor(ID struct_id, expr type_param_args, expr args)
 {
     expv result, component;
-    TYPE_DESC applied_type = NULL;
     TYPE_DESC base_stp;
     TYPE_DESC tp;
 

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -3395,7 +3395,6 @@ outx_FORALL_statement(int l, expv v)
     expv mask = EXPR_ARG2(v);
     expv body = EXPR_ARG3(v);
     const char *tid = NULL;
-    char buf[128];
 
     outx_vtagLineno(l, XTAG(v), EXPR_LINE(v), NULL);
 

--- a/F-FrontEnd/test/failtestdata/parameterized_type_invalid_type_parameter.f90
+++ b/F-FrontEnd/test/failtestdata/parameterized_type_invalid_type_parameter.f90
@@ -1,0 +1,6 @@
+       PROGRAM main
+         TYPE t
+           INTEGER, KIND :: k = kind(4)
+           INTEGER (KIND=k) :: v
+         END TYPE t
+       END PROGRAM main

--- a/F-FrontEnd/test/failtestdata/parameterized_type_invalid_type_parameter_2.f90
+++ b/F-FrontEnd/test/failtestdata/parameterized_type_invalid_type_parameter_2.f90
@@ -1,0 +1,7 @@
+       PROGRAM main
+         TYPE t (k)
+           INTEGER, KIND :: k = kind(4)
+           INTEGER, LEN :: k = 10
+           INTEGER (KIND=k) :: v
+         END TYPE t
+       END PROGRAM main


### PR DESCRIPTION
This pull request will add checking for the type paramter.

The follwing codes should be invalid:

```fortran
    TYPE t (l)
       INTEGER, KIND :: k = kind(4) ! not exists in type parameters
       INTEGER, LEN :: l = 10
       INTEGER, LEN :: l = 12 ! duplicate
       INTEGER(KIND=k) :: v
    END TYPE t
```