### PR TITLE
Improve the select type construct

### DIFF
--- a/F-BackEnd/src/xcodeml/f/decompile/XfDecompileDomVisitor.java
+++ b/F-BackEnd/src/xcodeml/f/decompile/XfDecompileDomVisitor.java
@@ -2244,18 +2244,23 @@ public class XfDecompileDomVisitor {
             XfTypeManagerForDom typeManager = _context.getTypeManagerForDom();
 
             String kind = XmDomUtil.getAttr(n, "kind");
-            String type = XmDomUtil.getAttr(n, "type");
+            String typeId = XmDomUtil.getAttr(n, "type");
             if(kind.equals("CLASS_DEFAULT")){
                 writer.writeToken("CLASS DEFAULT");
             } else {
-                String typeName = typeManager.getAliasTypeName(type);
                 if(kind.equals("CLASS_IS")){
                     writer.writeToken("CLASS IS");
                 } else if(kind.equals("TYPE_IS")){
                     writer.writeToken("TYPE IS");
                 }
                 writer.writeToken(" ( ");
-                writer.writeToken(typeName);
+                XfType type = XfType.getTypeIdFromXcodemlTypeName(typeId);
+                if (type.isPrimitive()) {
+                    writer.writeToken(type.fortranName());
+                } else {
+                    XfTypeManagerForDom.TypeList typeList = getTypeList(typeId);
+                    _writeTopType(typeList, false);
+                }
                 writer.writeToken(" ) ");
             }
 

--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -1570,7 +1570,9 @@ find_ident_block_parent(SYMBOL s)
     int in_block = FALSE;
 
     FOR_CTLS_BACKWARD(cp) {
-        if (CTL_TYPE(cp) == CTL_BLOCK || CTL_TYPE(cp) == CTL_FORALL) {
+        if (CTL_TYPE(cp) == CTL_BLOCK || \
+            CTL_TYPE(cp) == CTL_FORALL || \
+            CTL_TYPE(cp) == CTL_TYPE_GUARD) {
             in_block = TRUE;
             if (CTL_BLOCK_LOCAL_SYMBOLS(cp) == LOCAL_SYMBOLS) {
                 continue;

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -1118,7 +1118,7 @@ compile_statement1(int st_no, expr x)
             if (endlineno_flag)
                 EXPR_END_LINE_NO(CTL_BLOCK(ctl_top)) = current_line->ln_no;
 
-
+            check_select_types();
             pop_ctl();
         } else if (CTL_TYPE(ctl_top) == CTL_CASE ||
                    CTL_TYPE(ctl_top) == CTL_TYPE_GUARD) {
@@ -1152,6 +1152,7 @@ compile_statement1(int st_no, expr x)
             if (endlineno_flag)
                 EXPR_END_LINE_NO(CTL_BLOCK(ctl_top)) = current_line->ln_no;
 
+            check_select_types();
             pop_ctl();
         } else {
             error("'end select', out of place");
@@ -8416,8 +8417,7 @@ check_select_types()
             continue;
         }
 
-
-        FOR_ITEMS_IN_LIST(lp2, LIST_NEXT(lp1)) {
+        for (lp2 = LIST_NEXT(lp1); lp2 != NULL; lp2 = LIST_NEXT(lp2)) {
             statement2 = LIST_ITEM(lp2);
             if (EXPR_CODE(statement2) != F03_TYPEIS_STATEMENT &&
                 EXPR_CODE(statement2) != F03_CLASSIS_STATEMENT) {

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -8444,10 +8444,19 @@ check_select_types()
                 return;
             }
 
-            if (EXPR_CODE(statement1) == EXPR_CODE(statement2) &&
-                type_is_strict_compatible(tp1, tp2)) {
-                error("duplicate type in SELECT TYPE construct");
-                return;
+            if (tp1 == NULL || tp2 == NULL) {
+                continue;
+            }
+
+            if (EXPR_CODE(statement1) == EXPR_CODE(statement2)) {
+                if (IS_STRUCT_TYPE(tp1) && IS_STRUCT_TYPE(tp2)) {
+                    if (TYPE_TAGNAME(tp1) == TYPE_TAGNAME(tp2)) {
+                        error("duplicate type in SELECT TYPE construct");
+                    }
+                } else if (type_is_strict_compatible(tp1, tp2)) {
+                    error("duplicate type in SELECT TYPE construct");
+                    return;
+                }
             }
         }
     }

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -8488,10 +8488,10 @@ check_select_types()
             if (EXPR_CODE(statement1) == EXPR_CODE(statement2)) {
                 if (IS_STRUCT_TYPE(tp1) && IS_STRUCT_TYPE(tp2)) {
                     if (TYPE_TAGNAME(tp1) == TYPE_TAGNAME(tp2)) {
-                        error("duplicate type in SELECT TYPE construct");
+                        error("duplicate derived-types in SELECT TYPE construct");
                     }
                 } else if (type_is_strict_compatible(tp1, tp2)) {
-                    error("duplicate type in SELECT TYPE construct");
+                    error("duplicate types in SELECT TYPE construct");
                     return;
                 }
             }

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -132,6 +132,7 @@ static void compile_FORALL_statement(int st_no, expr x);
 static void compile_ENDFORALL_statement(expr x);
 
 static int check_valid_construction_name(expr x, expr y);
+static void move_implicit_vars_to_parent_from_type_guard(void);
 static void check_select_types(void);
 
 static void unify_submodule_symbol_table(void);
@@ -1077,6 +1078,7 @@ compile_statement1(int st_no, expr x)
                     if (endlineno_flag)
                          EXPR_END_LINE_NO(CTL_BLOCK(ctl_top)) = current_line->ln_no;
                     pop_ctl();
+                    move_implicit_vars_to_parent_from_type_guard();
                     pop_env();
 
                     parent_const_name = CTL_TYPE_GUARD_CONST_NAME(ctl_top);
@@ -1142,6 +1144,7 @@ compile_statement1(int st_no, expr x)
                 EXPR_END_LINE_NO(CTL_BLOCK(ctl_top)) = current_line->ln_no;
 
             pop_ctl();
+            move_implicit_vars_to_parent_from_type_guard();
             pop_env();
 
             if (CTL_TYPE(ctl_top) != CTL_SELECT &&

--- a/F-FrontEnd/src/F-front.h
+++ b/F-FrontEnd/src/F-front.h
@@ -259,7 +259,11 @@ typedef struct control
 #define CTL_WHERE_ELSE(l)          (EXPR_ARG3((l)->v2))
 
 #define CTL_SELECT_STATEMENT_BODY(l)    (EXPR_ARG2((l)->v1))
-#define CTL_CASE_BLOCK(l)     (EXPR_ARG2((l)->v1))
+#define CTL_SELECT_CONST_NAME(l)        (EXPR_ARG3((l)->v1))
+#define CTL_CASE_BLOCK(l)               (EXPR_ARG2((l)->v1))
+#define CTL_CASE_CONST_NAME(l)          (EXPR_ARG3((l)->v1))
+#define CTL_TYPE_GUARD_BLOCK(l)         (EXPR_ARG2((l)->v1))
+#define CTL_TYPE_GUARD_CONST_NAME(l)    (EXPR_ARG3((l)->v1))
 
 #define CTL_OMP_ARG(l)	((l)->v2)
 #define CTL_OMP_ARG_DIR(l) (EXPR_INT(EXPR_ARG1((l)->v2)))

--- a/F-FrontEnd/src/F-front.h
+++ b/F-FrontEnd/src/F-front.h
@@ -717,6 +717,7 @@ extern int      type_bound_procedure_type_match _ANSI_ARGS_((EXT_ID f1, EXT_ID f
 extern int      is_procedure_acceptable _ANSI_ARGS_((EXT_ID proc, expv actual_args));
 
 extern int      type_is_soft_compatible _ANSI_ARGS_((TYPE_DESC tp, TYPE_DESC tq));
+extern int      type_is_strict_compatible _ANSI_ARGS_((TYPE_DESC tp, TYPE_DESC tq));
 extern int      type_is_compatible_for_assignment
                     _ANSI_ARGS_((TYPE_DESC tp1, TYPE_DESC tp2));
 extern int      struct_type_is_compatible_for_assignment

--- a/F-FrontEnd/src/F-front.h
+++ b/F-FrontEnd/src/F-front.h
@@ -162,6 +162,8 @@ enum control_type {
     CTL_ELSE_WHERE,
     CTL_SELECT,
     CTL_CASE,
+    CTL_SELECT_TYPE,
+    CTL_TYPE_GUARD,
     CTL_STRUCT,
     CTL_OMP,
     CTL_XMP,

--- a/F-FrontEnd/src/F-front.h
+++ b/F-FrontEnd/src/F-front.h
@@ -260,10 +260,13 @@ typedef struct control
 
 #define CTL_SELECT_STATEMENT_BODY(l)    (EXPR_ARG2((l)->v1))
 #define CTL_SELECT_CONST_NAME(l)        (EXPR_ARG3((l)->v1))
+#define CTL_SELECT_TYPE_SELECTOR(l)     (EXPR_ARG1((l)->v1))
+#define CTL_SELECT_TYPE_ASSICIATE(l)    (EXPR_ARG4((l)->v1))
 #define CTL_CASE_BLOCK(l)               (EXPR_ARG2((l)->v1))
 #define CTL_CASE_CONST_NAME(l)          (EXPR_ARG3((l)->v1))
 #define CTL_TYPE_GUARD_BLOCK(l)         (EXPR_ARG2((l)->v1))
 #define CTL_TYPE_GUARD_CONST_NAME(l)    (EXPR_ARG3((l)->v1))
+#define CTL_TYPE_GUARD_LOCAL_ENV(l)     (&((l)->local_env))
 
 #define CTL_OMP_ARG(l)	((l)->v2)
 #define CTL_OMP_ARG_DIR(l) (EXPR_INT(EXPR_ARG1((l)->v2)))

--- a/F-FrontEnd/src/F95-lex.c
+++ b/F-FrontEnd/src/F95-lex.c
@@ -1913,10 +1913,11 @@ get_keyword_optional_blank(int class)
     case KW_TYPE:
         if(get_keyword(keywords) == KW_IS) return TYPEIS;
         break;
-    case KW_SELECT:
-        if(get_keyword(keywords) == CASE) return SELECT;
-        if(get_keyword(keywords) == KW_TYPE) return SELECTTYPE;
-        break;
+    case KW_SELECT: {
+        int kwd = get_keyword(keywords);
+        if(kwd == CASE) return SELECT;
+        if(kwd == KW_TYPE) return SELECTTYPE;
+    } break;
     case DO: /* DO WHILE *//* blanks mandatory.  */
         if(get_keyword(keywords) == KW_WHILE) return DOWHILE;
         break;

--- a/F-FrontEnd/src/F95-lex.c
+++ b/F-FrontEnd/src/F95-lex.c
@@ -1915,6 +1915,7 @@ get_keyword_optional_blank(int class)
         break;
     case KW_SELECT:
         if(get_keyword(keywords) == CASE) return SELECT;
+        if(get_keyword(keywords) == KW_TYPE) return SELECTTYPE;
         break;
     case DO: /* DO WHILE *//* blanks mandatory.  */
         if(get_keyword(keywords) == KW_WHILE) return DOWHILE;

--- a/F-FrontEnd/src/F95-lex.c
+++ b/F-FrontEnd/src/F95-lex.c
@@ -3949,6 +3949,7 @@ struct keyword_token keywords[ ] =
     { "save",           SAVE },
     { "selectcase",     SELECT },
     { "select",         KW_SELECT },
+    { "selecttype",     SELECTTYPE },  /* F2003 spec */
     { "sequence",       SEQUENCE },
     /*    { "static",   KW_STATIC },*/
     { "stop",           STOP },

--- a/F-FrontEnd/src/F95-parser.y
+++ b/F-FrontEnd/src/F95-parser.y
@@ -1704,10 +1704,6 @@ executable_statement:
         { $$ = list0(F_ENDWHERE_STATEMENT); }
         | SELECT '(' expr ')'
         { $$ = list2(F_SELECTCASE_STATEMENT, $3, st_name); }
-        | KW_SELECT KW KW_TYPE '(' expr ')'
-        { $$ = list2(F03_SELECTTYPE_STATEMENT, $5, st_name); }
-        | KW_SELECT KW KW_TYPE '(' IDENTIFIER REF_OP expr ')'
-        { $$ = list3(F03_SELECTTYPE_STATEMENT, $7, st_name, $5); }
         | SELECTTYPE '(' expr ')'
         { $$ = list2(F03_SELECTTYPE_STATEMENT, $3, st_name); }
         | SELECTTYPE '(' IDENTIFIER REF_OP expr ')'

--- a/F-FrontEnd/src/F95-parser.y
+++ b/F-FrontEnd/src/F95-parser.y
@@ -1721,7 +1721,7 @@ executable_statement:
         | CLASSIS '(' IDENTIFIER ')' name_or_null
         { $$ = list2(F03_CLASSIS_STATEMENT, $3, $5); }
         | TYPEIS '(' IDENTIFIER ')' name_or_null
-        { $$ = list2(F03_TYPEIS_STATEMENT, $3, $5); }  
+        { $$ = list2(F03_TYPEIS_STATEMENT, $3, $5); }
         | CLASSDEFAULT name_or_null
         { $$ = list2(F03_CLASSIS_STATEMENT, NULL, $2); }
         | FORALL '(' forall_header ')' assign_statement_or_null

--- a/F-FrontEnd/src/F95-parser.y
+++ b/F-FrontEnd/src/F95-parser.y
@@ -1718,10 +1718,10 @@ executable_statement:
         { $$ = list1(F2008_BLOCK_STATEMENT,st_name); }
         | ENDBLOCK name_or_null
         { $$ = list1(F2008_ENDBLOCK_STATEMENT,$2); }
-        | CLASSIS '(' IDENTIFIER ')' name_or_null
-        { $$ = list2(F03_CLASSIS_STATEMENT, $3, $5); }
-        | TYPEIS '(' IDENTIFIER ')' name_or_null
-        { $$ = list2(F03_TYPEIS_STATEMENT, $3, $5); }
+        | CLASSIS '(' TYPE_KW expr_type_spec ')' name_or_null
+        { $$ = list2(F03_CLASSIS_STATEMENT, $4, $6); }
+        | TYPEIS '(' TYPE_KW expr_type_spec ')' name_or_null
+        { $$ = list2(F03_TYPEIS_STATEMENT, $4, $6); }
         | CLASSDEFAULT name_or_null
         { $$ = list2(F03_CLASSIS_STATEMENT, NULL, $2); }
         | FORALL '(' forall_header ')' assign_statement_or_null

--- a/F-FrontEnd/src/F95-parser.y
+++ b/F-FrontEnd/src/F95-parser.y
@@ -143,6 +143,7 @@ state 2058
 %token ENDSUBROUTINE
 %token ENDBLOCKDATA
 %token SELECT   /* select case */
+%token SELECTTYPE   /* select type F03 keyword */
 %token CASEDEFAULT /* case defualt */
 %token CASE     /* case */
 %token ENDSELECT
@@ -1707,6 +1708,10 @@ executable_statement:
         { $$ = list2(F03_SELECTTYPE_STATEMENT, $5, st_name); }
         | KW_SELECT KW KW_TYPE '(' IDENTIFIER REF_OP expr ')'
         { $$ = list3(F03_SELECTTYPE_STATEMENT, $7, st_name, $5); }
+        | SELECTTYPE '(' expr ')'
+        { $$ = list2(F03_SELECTTYPE_STATEMENT, $3, st_name); }
+        | SELECTTYPE '(' IDENTIFIER REF_OP expr ')'
+        { $$ = list3(F03_SELECTTYPE_STATEMENT, $5, st_name, $3); }
         | CASE '(' scene_list ')' name_or_null
         { $$ = list2(F_CASELABEL_STATEMENT, $3, $5); }
         | CASEDEFAULT name_or_null

--- a/F-FrontEnd/test/failtestdata/select_type_duplicate_class_default.f90
+++ b/F-FrontEnd/test/failtestdata/select_type_duplicate_class_default.f90
@@ -1,0 +1,11 @@
+
+program main
+ contains
+  subroutine sub(p)
+    class(*) :: p 
+    select type (p)
+      class default
+      class default
+    end select
+  end subroutine sub
+end program main

--- a/F-FrontEnd/test/failtestdata/select_type_duplicate_primitive_types.f90
+++ b/F-FrontEnd/test/failtestdata/select_type_duplicate_primitive_types.f90
@@ -1,0 +1,11 @@
+
+program main
+ contains
+  subroutine sub(p)
+    class(*) :: p 
+    select type (p)
+      type is (integer)
+      type is (integer)
+    end select
+  end subroutine sub
+end program main

--- a/F-FrontEnd/test/testdata/select_type.f90
+++ b/F-FrontEnd/test/testdata/select_type.f90
@@ -30,7 +30,6 @@ contains
         print*,'class default'
     end select cname
 
-
     select type (assoc_name=>p)
       class is(point)
         print*,'class is point',assoc_name%x

--- a/F-FrontEnd/test/testdata/select_type.f90
+++ b/F-FrontEnd/test/testdata/select_type.f90
@@ -34,8 +34,8 @@ contains
     select type (assoc_name=>p)
       class is(point)
         print*,'class is point',assoc_name%x
-      !class is(color_point)
-      !  print*,'class is color_point',assoc_name%color
+      class is(color_point)
+        print*,'class is color_point',assoc_name%color
       class default
         print*,'default'
     end select

--- a/F-FrontEnd/test/testdata/select_type_with_primitive_types.f90
+++ b/F-FrontEnd/test/testdata/select_type_with_primitive_types.f90
@@ -1,0 +1,18 @@
+
+program main
+ contains
+  subroutine sub(p)
+    class(*) :: p 
+
+    select type (p)
+      type is(integer(kind=4))
+        print*,'p is integer(kind=4)'
+      type is(integer(kind=8))
+        print*,'p is integer(kind=8)'
+      type is(real)
+        print*,'p is real'
+      class default
+        print*,'p is unknown type'
+    end select
+  end subroutine sub
+end program main


### PR DESCRIPTION
This pull request has following improvments for the select type construct:
 - accepts intrinsic types in TYPE IS/ CLASS IS statement
   ```fortran
     SELECT TYPE (p)
         TYPE IS (INTEGER(KIND=4))
         TYPE IS (INTEGER(KIND=8))
     END SELECT TYPE
    ```
 - changes a type of selector inside a type guard clause
   ```fortran
     SELECT TYPE (p)
         TYPE IS (t)
           WRITE(*,*) p%member
         TYPE IS (subtype_of_t)
           WRITE(*,*) p%member_of_sub_type
     END SELECT TYPE
    ```
  - checks types in TYPE IS / CLASS IS statement
   ```fortran
     SELECT TYPE (p)
         TYPE IS (INTEGER)
         TYPE IS (INTEGER) ! this statement will cause error
     END SELECT TYPE
    ```
