### PR TITLE
Skip initialization of allocatable member 

### DIFF
--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -2712,7 +2712,24 @@ compile_struct_constructor_with_components(const ID struct_id,
 
     // check not initialized type parameters
     FOREACH_ID(ip, members) {
-        if (ID_CLASS(ip) != CL_TYPE_BOUND_PROC && !VAR_INIT_VALUE(ip)) {
+        int is_initialized = FALSE;
+
+        if (ID_CLASS(ip) != CL_TYPE_BOUND_PROC) {
+            is_initialized = TRUE;
+        }
+
+        if (ID_TYPE(ip) && TYPE_IS_ALLOCATABLE(ID_TYPE(ip))) {
+            /*
+             * Allocatable member can skip initialization.
+             */
+            is_initialized = TRUE;
+        }
+
+        if (!VAR_INIT_VALUE(ip)) {
+            is_initialized = TRUE;
+        }
+
+        if (! is_initialized) {
             error("member %s is not initialized", ID_NAME(ip));
             return NULL;
         }

--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -2710,28 +2710,14 @@ compile_struct_constructor_with_components(const ID struct_id,
         list_put_last(components, v);
     }
 
-    // check not initialized type parameters
+    /*
+     * check all members are initialized
+     */
     FOREACH_ID(ip, members) {
-        int is_initialized = FALSE;
-
-        if (ID_CLASS(ip) != CL_TYPE_BOUND_PROC) {
-            is_initialized = TRUE;
-        }
-
-        if (ID_TYPE(ip) && TYPE_IS_ALLOCATABLE(ID_TYPE(ip))) {
-            /*
-             * Allocatable member can skip initialization.
-             */
-            is_initialized = TRUE;
-        }
-
-        if (!VAR_INIT_VALUE(ip)) {
-            is_initialized = TRUE;
-        }
-
-        if (! is_initialized) {
+        if (ID_CLASS(ip) != CL_TYPE_BOUND_PROC && (
+                !VAR_INIT_VALUE(ip) &&
+                !TYPE_IS_ALLOCATABLE(ID_TYPE(ip)))) {
             error("member %s is not initialized", ID_NAME(ip));
-            return NULL;
         }
     }
 

--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -2623,8 +2623,10 @@ get_struct_members(TYPE_DESC struct_tp)
 }
 
 
-static int
-compile_struct_constructor_components(ID struct_id, TYPE_DESC struct_tp, expr args, expv components)
+static expv
+compile_struct_constructor_with_components(const ID struct_id,
+                                           const TYPE_DESC stp,
+                                           const expr args)
 {
     int has_keyword = FALSE;
     list lp;
@@ -2632,16 +2634,16 @@ compile_struct_constructor_components(ID struct_id, TYPE_DESC struct_tp, expr ar
     ID match = NULL;
     SYMBOL sym;
     expv v;
+    expv result, components;
+    TYPE_DESC tp;
+    components = list0(LIST);
+    result = list2(F95_STRUCT_CONSTRUCTOR, NULL, components);
 
     // Check PRIVATE components
     // (PRIVATE works if the derived type is use-associated)
     int is_use_associated = ID_USEASSOC_INFO(struct_id) != NULL;
 
-    if (struct_tp == NULL) {
-        struct_tp = ID_TYPE(struct_id);
-    }
-
-    members = get_struct_members(struct_tp);
+    members = get_struct_members(stp?:ID_TYPE(struct_id));
     cur = members;
 
     FOR_ITEMS_IN_LIST(lp, args) {
@@ -2658,12 +2660,12 @@ compile_struct_constructor_components(ID struct_id, TYPE_DESC struct_tp, expr ar
             // check keyword is duplicate
             if (find_ident_head(sym, used) != NULL) {
                 error("member'%s' is already specified", SYM_NAME(sym));
-                return FALSE;
+                return NULL;
             }
 
             if ((match = find_ident_head(sym, members)) == NULL) {
                 error("'%s' is not member", SYM_NAME(sym));
-                return FALSE;
+                return NULL;
             }
         } else {
             sym = NULL;
@@ -2671,12 +2673,12 @@ compile_struct_constructor_components(ID struct_id, TYPE_DESC struct_tp, expr ar
             if (has_keyword == TRUE) {
                 // KEYWORD connot be ommit after KEYWORD-ed arg
                 error("KEYWORD connot be ommited after the component with a keyword");
-                return FALSE;
+                return NULL;
             }
 
             if (cur == NULL) {
                 error("unexpected member");
-                return FALSE;
+                return NULL;
             }
 
             match = cur;
@@ -2688,7 +2690,7 @@ compile_struct_constructor_components(ID struct_id, TYPE_DESC struct_tp, expr ar
              !(TYPE_IS_PUBLIC(match) ||
                TYPE_IS_PUBLIC(ID_TYPE(match))))) {
             error("accessing a private component");
-            return FALSE;
+            return NULL;
         }
 
         v = compile_expression(arg);
@@ -2696,7 +2698,7 @@ compile_struct_constructor_components(ID struct_id, TYPE_DESC struct_tp, expr ar
         if (!type_is_compatible_for_assignment(ID_TYPE(match),
                                                EXPV_TYPE(v))) {
             error("type is not applicable in struct constructor");
-            return FALSE;
+            return NULL;
         }
 
         if (!has_keyword) {
@@ -2712,11 +2714,19 @@ compile_struct_constructor_components(ID struct_id, TYPE_DESC struct_tp, expr ar
     FOREACH_ID(ip, members) {
         if (ID_CLASS(ip) != CL_TYPE_BOUND_PROC && !VAR_INIT_VALUE(ip)) {
             error("member %s is not initialized", ID_NAME(ip));
-            return FALSE;
+            return NULL;
         }
     }
-    return TRUE;
 
+    if (TYPE_REF(stp)) {
+        tp = stp;
+    } else {
+        tp = wrap_type(stp);
+    }
+
+    EXPV_TYPE(result) = tp;
+
+    return result;
 }
 
 
@@ -2746,12 +2756,9 @@ compile_struct_constructor(ID struct_id, expr type_param_args, expr args)
         tp = base_stp;
     }
 
-    if(args) {
+    if (args) {
         EXPV_LINE(result) = EXPR_LINE(args);
-        if (!compile_struct_constructor_components(struct_id, tp,
-                                                   args, component)) {
-            return NULL;
-        }
+        return compile_struct_constructor_with_components(struct_id, tp, args);
     }
 
     if (tp == base_stp) {

--- a/F-FrontEnd/test/testdata/type_constractor_skip_allocatable_member.f90
+++ b/F-FrontEnd/test/testdata/type_constractor_skip_allocatable_member.f90
@@ -1,0 +1,10 @@
+  PROGRAM main
+    TYPE :: t
+      INTEGER :: v
+      INTEGER, ALLOCATABLE, DIMENSION(:) :: w
+    END TYPE
+
+    TYPE(t) :: a
+
+    a = t(1)
+  END PROGRAM main


### PR DESCRIPTION
This pull-request will skip the derived-type member initialization if it is allocatable

ex)
```fortran
    TYPE t
       INTEGER :: v
       INTEGER, ALLOCATABLE, DIMENSION(:) :: w
    END TYPE t

    TYPE(t) :: a = t(v=1) ! skip initialization of member 'w'
```