### PR TITLE
Enable the XMPT tool to store data in the data object

### DIFF
--- a/XcodeML-Exc-Tools/src/exc/xcalablemp/XMPtranslateLocalPragma.java
+++ b/XcodeML-Exc-Tools/src/exc/xcalablemp/XMPtranslateLocalPragma.java
@@ -917,7 +917,7 @@ public class XMPtranslateLocalPragma {
       xmptArgs.add(onRefObj.getDescId().Ref());
 
       Ident xmptDataId = pb.getParentBlock().getBody().declLocalIdent(tmpSym.getStr("xmpt_data"), Xtype.voidPtrType);
-      xmptArgs.add(xmptDataId.Ref());
+      xmptArgs.add(xmptDataId.getAddr());
 
       for (XobjArgs i = onRef.getArg(1).getArgs(); i != null; i = i.nextArgs()){
 	//xmptArgs.add(i.getArg());
@@ -931,7 +931,7 @@ public class XMPtranslateLocalPragma {
 
       // event_loop_end
       xmptFuncId = _globalDecl.declExternFunc("_XMP_loop_end");
-      xmptArgs = Xcons.List(xmptDataId.Ref());
+      xmptArgs = Xcons.List(xmptDataId.getAddr());
       loopBody.add(xmptFuncId.Call(xmptArgs));
     }
 	      

--- a/libxmp/src/xmp_async.c
+++ b/libxmp/src/xmp_async.c
@@ -107,7 +107,7 @@ void _XMP_wait_async__(int async_id)
   _XMP_async_comm_t *async;
 
 #ifdef _XMPT
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
   if (xmpt_enabled && xmpt_callback[xmpt_event_wait_async_begin]){
     //    xmp_desc_t on_desc;
     //    struct _xmpt_subscript_t on_subsc;
@@ -115,7 +115,7 @@ void _XMP_wait_async__(int async_id)
       (xmpt_async_id_t)async_id,
       &on_desc,
       &on_subsc,
-      data);
+      &data);
   }
 #endif
   
@@ -157,7 +157,7 @@ void _XMP_wait_async__(int async_id)
 
 #ifdef _XMPT
   if (xmpt_enabled && xmpt_callback[xmpt_event_wait_async_end])
-    (*(xmpt_event_end_t)xmpt_callback[xmpt_event_wait_async_end])(data);
+    (*(xmpt_event_end_t)xmpt_callback[xmpt_event_wait_async_end])(&data);
 #endif
 
 }

--- a/libxmp/src/xmp_barrier.c
+++ b/libxmp/src/xmp_barrier.c
@@ -29,7 +29,7 @@ void _XMP_barrier(_XMP_object_ref_t *desc)
   _XMP_RETURN_IF_SINGLE;
 
 #ifdef _XMPT
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
 
   xmp_desc_t on;
   if (desc){
@@ -46,7 +46,7 @@ void _XMP_barrier(_XMP_object_ref_t *desc)
     (*(xmpt_event_single_desc_begin_t)xmpt_callback[xmpt_event_barrier_begin])(
 	on,
 	&on_subsc,
-	data);
+	&data);
   }
 #endif
 
@@ -75,7 +75,7 @@ void _XMP_barrier(_XMP_object_ref_t *desc)
 
 #ifdef _XMPT
   if (xmpt_enabled && xmpt_callback[xmpt_event_barrier_end])
-    (*(xmpt_event_end_t)xmpt_callback[xmpt_event_barrier_end])(data);
+    (*(xmpt_event_end_t)xmpt_callback[xmpt_event_barrier_end])(&data);
 #endif
   
 }

--- a/libxmp/src/xmp_bcast.c
+++ b/libxmp/src/xmp_bcast.c
@@ -436,7 +436,7 @@ void _XMP_bcast(void *data_addr, int count, int size,
 		_XMP_object_ref_t *from_desc, _XMP_object_ref_t *on_desc)
 {
 #ifdef _XMPT
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
 
   xmp_desc_t on;
   if (on_desc){
@@ -474,7 +474,7 @@ void _XMP_bcast(void *data_addr, int count, int size,
 	on,
 	&on_subsc,
         async_id,
-	data);
+	&data);
     }
   }
   else {
@@ -486,7 +486,7 @@ void _XMP_bcast(void *data_addr, int count, int size,
 	&from_subsc,
 	on,
 	&on_subsc,
-	data);
+	&data);
     }
   }
 #endif
@@ -498,7 +498,7 @@ void _XMP_bcast(void *data_addr, int count, int size,
 
 #ifdef _XMPT
   if (xmpt_enabled && xmpt_callback[xmpt_event_bcast_end])
-    (*(xmpt_event_end_t)xmpt_callback[xmpt_event_bcast_end])(data);
+    (*(xmpt_event_end_t)xmpt_callback[xmpt_event_bcast_end])(&data);
 #endif
 
 }

--- a/libxmp/src/xmp_coarray.c
+++ b/libxmp/src/xmp_coarray.c
@@ -1144,7 +1144,7 @@ void _XMP_coarray_put(void *remote_coarray, void *local_array, void *local_coarr
 
 #ifdef _XMPT
   struct _xmpt_subscript_t subsc, cosubsc;
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
   if (xmpt_enabled && xmpt_callback[xmpt_event_coarray_remote_write]){
     subsc.ndims = _array_dims;
     subsc.omit = 0;
@@ -1161,7 +1161,7 @@ void _XMP_coarray_put(void *remote_coarray, void *local_array, void *local_coarr
       cosubsc.marker[i] = 0;
     }
     (*(xmpt_event_coarray_remote_t)xmpt_callback[xmpt_event_coarray_remote_write])(
-     (xmpt_coarray_id_t)remote_coarray, &subsc, &cosubsc, data);
+     (xmpt_coarray_id_t)remote_coarray, &subsc, &cosubsc, &data);
   }
 #endif
 
@@ -1225,7 +1225,7 @@ void _XMP_coarray_get(void *remote_coarray, void *local_array, void *local_coarr
 
 #ifdef _XMPT
   struct _xmpt_subscript_t subsc, cosubsc;
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
   if (xmpt_enabled && xmpt_callback[xmpt_event_coarray_remote_read]){
     subsc.ndims = _array_dims;
     subsc.omit = 0;
@@ -1242,7 +1242,7 @@ void _XMP_coarray_get(void *remote_coarray, void *local_array, void *local_coarr
       cosubsc.marker[i] = 0;
     }
     (*(xmpt_event_coarray_remote_t)xmpt_callback[xmpt_event_coarray_remote_read])(
-     (xmpt_coarray_id_t)remote_coarray, &subsc, &cosubsc, data);
+     (xmpt_coarray_id_t)remote_coarray, &subsc, &cosubsc, &data);
   }
 #endif
 
@@ -1406,10 +1406,10 @@ void xmp_sync_memory(const int* status)
 {
 
 #ifdef _XMPT
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
   if (xmpt_enabled && xmpt_callback[xmpt_event_sync_memory_begin])
     (*(xmpt_event_begin_t)xmpt_callback[xmpt_event_sync_memory_begin])(
-     data);
+     &data);
 #endif
 
 #ifdef _XMP_GASNET
@@ -1425,7 +1425,7 @@ void xmp_sync_memory(const int* status)
 #ifdef _XMPT
   if (xmpt_enabled && xmpt_callback[xmpt_event_sync_memory_end])
     (*(xmpt_event_end_t)xmpt_callback[xmpt_event_sync_memory_end])(
-     data);
+     &data);
 #endif
 }
 
@@ -1436,10 +1436,10 @@ void xmp_sync_all(const int* status)
 {
 
 #ifdef _XMPT
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
   if (xmpt_enabled && xmpt_callback[xmpt_event_sync_all_begin])
     (*(xmpt_event_begin_t)xmpt_callback[xmpt_event_sync_all_begin])(
-     data);
+     &data);
 #endif
 
 #ifdef _XMP_GASNET
@@ -1453,7 +1453,7 @@ void xmp_sync_all(const int* status)
 #ifdef _XMPT
   if (xmpt_enabled && xmpt_callback[xmpt_event_sync_all_end])
     (*(xmpt_event_end_t)xmpt_callback[xmpt_event_sync_all_end])(
-     data);
+     &data);
 #endif
 }
 
@@ -1464,10 +1464,10 @@ void xmp_sync_images(const int num, int* image_set, int* status)
 {
 
 #ifdef _XMPT
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
   if (xmpt_enabled && xmpt_callback[xmpt_event_sync_images_begin])
     (*(xmpt_event_sync_images_begin_t)xmpt_callback[xmpt_event_sync_images_begin])(
-     num, image_set, data);
+     num, image_set, &data);
 #endif
 
 #ifdef _XMP_GASNET
@@ -1481,7 +1481,7 @@ void xmp_sync_images(const int num, int* image_set, int* status)
 #ifdef _XMPT
   if (xmpt_enabled && xmpt_callback[xmpt_event_sync_images_end])
     (*(xmpt_event_end_t)xmpt_callback[xmpt_event_sync_images_end])(
-     data);
+     &data);
 #endif
 }
 
@@ -1522,7 +1522,7 @@ void _XMP_coarray_contiguous_put(const int target_image, _XMP_coarray_t *dst_des
   
 #ifdef _XMPT
   struct _xmpt_subscript_t subsc, cosubsc;
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
   if (xmpt_enabled && xmpt_callback[xmpt_event_coarray_remote_write]){
     subsc.ndims = dst_desc->coarray_dims;
     subsc.omit = 0;
@@ -1560,7 +1560,7 @@ void _XMP_coarray_contiguous_put(const int target_image, _XMP_coarray_t *dst_des
     }
 
     (*(xmpt_event_coarray_remote_t)xmpt_callback[xmpt_event_coarray_remote_write])(
-     (xmpt_coarray_id_t)dst_desc, &subsc, &cosubsc, data);
+     (xmpt_coarray_id_t)dst_desc, &subsc, &cosubsc, &data);
   }
 #endif
 
@@ -1608,7 +1608,7 @@ void _XMP_coarray_contiguous_get(const int target_image, _XMP_coarray_t *dst_des
  
 #ifdef _XMPT
   struct _xmpt_subscript_t subsc, cosubsc;
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
   if (xmpt_enabled && xmpt_callback[xmpt_event_coarray_remote_read]){
     subsc.ndims = src_desc->coarray_dims;
     subsc.omit = 0;
@@ -1646,7 +1646,7 @@ void _XMP_coarray_contiguous_get(const int target_image, _XMP_coarray_t *dst_des
     }
 
     (*(xmpt_event_coarray_remote_t)xmpt_callback[xmpt_event_coarray_remote_read])(
-     (xmpt_coarray_id_t)src_desc, &subsc, &cosubsc, data);
+     (xmpt_coarray_id_t)src_desc, &subsc, &cosubsc, &data);
   }
 #endif
 

--- a/libxmp/src/xmp_reduce.c
+++ b/libxmp/src/xmp_reduce.c
@@ -704,7 +704,7 @@ void _XMP_reduction(void *data_addr, int count, int datatype, int op,
   _XMP_nodes_t *nodes;
 
 #ifdef _XMPT
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
 
   xmp_desc_t on;
   if (r_desc){
@@ -726,7 +726,7 @@ void _XMP_reduction(void *data_addr, int count, int datatype, int op,
 	on,
 	&on_subsc,
         async_id,
-	data);
+	&data);
     }
   }
   else {
@@ -734,7 +734,7 @@ void _XMP_reduction(void *data_addr, int count, int datatype, int op,
       (*(xmpt_event_single_desc_begin_t)xmpt_callback[xmpt_event_reduction_begin])(
 	on,
 	&on_subsc,
-	data);
+	&data);
     }
   }
 #endif
@@ -777,7 +777,7 @@ void _XMP_reduction(void *data_addr, int count, int datatype, int op,
 
 #ifdef _XMPT
   if (xmpt_enabled && xmpt_callback[xmpt_event_reduction_end])
-    (*(xmpt_event_end_t)xmpt_callback[xmpt_event_reduction_end])(data);
+    (*(xmpt_event_end_t)xmpt_callback[xmpt_event_reduction_end])(&data);
 #endif
 
 }

--- a/libxmp/src/xmp_reflect.c
+++ b/libxmp/src/xmp_reflect.c
@@ -145,7 +145,7 @@ void _XMP_reflect__(_XMP_array_t *a)
   }
 
 #ifdef _XMPT
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
   if (xmpt_enabled && xmpt_callback[xmpt_event_reflect_begin]){
     struct _xmpt_subscript_t subsc;
     subsc.ndims = a->dim;;
@@ -156,7 +156,7 @@ void _XMP_reflect__(_XMP_array_t *a)
       subsc.marker[i] = _xmp_is_periodic[i];
     }
     (*(xmpt_event_single_desc_begin_t)xmpt_callback[xmpt_event_reflect_begin])(
-      a, &subsc, data);
+      a, &subsc, &data);
   }
 #endif
   
@@ -240,7 +240,7 @@ void _XMP_reflect__(_XMP_array_t *a)
 #ifdef _XMPT
   if (xmpt_enabled && xmpt_callback[xmpt_event_reflect_end])
     (*(xmpt_event_end_t)xmpt_callback[xmpt_event_reflect_end])(
-     data);
+     &data);
 #endif
 
 }
@@ -902,7 +902,7 @@ void _XMP_reflect_async__(_XMP_array_t *a, int async_id){
   }
 
 #ifdef _XMPT
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
   if (xmpt_enabled && xmpt_callback[xmpt_event_reflect_begin_async]){
     struct _xmpt_subscript_t subsc;
     subsc.ndims = a->dim;;
@@ -913,7 +913,7 @@ void _XMP_reflect_async__(_XMP_array_t *a, int async_id){
       subsc.marker[i] = _xmp_is_periodic[i];
     }
     (*(xmpt_event_single_desc_begin_async_t)xmpt_callback[xmpt_event_reflect_begin_async])(
-      a, &subsc, (xmpt_async_id_t)async_id, data);
+      a, &subsc, (xmpt_async_id_t)async_id, &data);
   }
 #endif
 
@@ -944,7 +944,7 @@ void _XMP_reflect_async__(_XMP_array_t *a, int async_id){
 #ifdef _XMPT
   if (xmpt_enabled && xmpt_callback[xmpt_event_reflect_end])
     (*(xmpt_event_end_t)xmpt_callback[xmpt_event_reflect_end])(
-      data);
+      &data);
 #endif
 
 }
@@ -1280,7 +1280,7 @@ void _XMP_reflect__(_XMP_array_t *a)
   }
 
 #ifdef _XMPT
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
   if (xmpt_enabled && xmpt_callback[xmpt_event_reflect_begin]){
     struct _xmpt_subscript_t subsc;
     subsc.ndims = a->dim;;
@@ -1291,7 +1291,7 @@ void _XMP_reflect__(_XMP_array_t *a)
       subsc.marker[i] = _xmp_is_periodic[i];
     }
     (*(xmpt_event_single_desc_begin_t)xmpt_callback[xmpt_event_reflect_begin])(
-      a, &subsc, data);
+      a, &subsc, &data);
   }
 #endif
 
@@ -1348,7 +1348,7 @@ void _XMP_reflect__(_XMP_array_t *a)
 #ifdef _XMPT
   if (xmpt_enabled && xmpt_callback[xmpt_event_reflect_end])
     (*(xmpt_event_end_t)xmpt_callback[xmpt_event_reflect_end])(
-      data);
+      &data);
 #endif
 
 }
@@ -1626,7 +1626,7 @@ void _XMP_reflect_async__(_XMP_array_t *a, int async_id)
   }
     
 #ifdef _XMPT
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
   if (xmpt_enabled && xmpt_callback[xmpt_event_reflect_begin_async]){
     struct _xmpt_subscript_t subsc;
     subsc.ndims = a->dim;;
@@ -1637,7 +1637,7 @@ void _XMP_reflect_async__(_XMP_array_t *a, int async_id)
       subsc.marker[i] = _xmp_is_periodic[i];
     }
     (*(xmpt_event_single_desc_begin_async_t)xmpt_callback[xmpt_event_reflect_begin_async])(
-      a, subsc, (xmpt_async_id_t)async_id, data);
+      a, subsc, (xmpt_async_id_t)async_id, &data);
   }
 #endif
 
@@ -1663,7 +1663,7 @@ void _XMP_reflect_async__(_XMP_array_t *a, int async_id)
 #ifdef _XMPT
   if (xmpt_enabled && xmpt_callback[xmpt_event_reflect_end])
     (*(xmpt_event_end_t)xmpt_callback[xmpt_event_reflect_end])(
-      data);
+      &data);
 #endif
 
 }

--- a/libxmp/src/xmpc_gmove.c
+++ b/libxmp/src/xmpc_gmove.c
@@ -157,7 +157,7 @@ xmpc_gmv_do(_XMP_gmv_desc_t *gmv_desc_leftp, _XMP_gmv_desc_t *gmv_desc_rightp,
   _XMP_unpack_comm_set = _XMPC_unpack_comm_set;
 
 #ifdef _XMPT
-  xmpt_tool_data_t *data = NULL;
+  xmpt_tool_data_t data = NULL;
   struct _xmpt_subscript_t lhs_subsc, rhs_subsc;
   _XMPT_set_gmove_subsc(&lhs_subsc, gmv_desc_leftp);
   _XMPT_set_gmove_subsc(&rhs_subsc, gmv_desc_rightp);
@@ -179,12 +179,12 @@ xmpc_gmv_do(_XMP_gmv_desc_t *gmv_desc_leftp, _XMP_gmv_desc_t *gmv_desc_rightp,
 	(*(xmpt_event_gmove_begin_t)xmpt_callback[xmpt_event_gmove_begin])
 	  (gmv_desc_leftp->a_desc, &lhs_subsc,
 	   gmv_desc_rightp->a_desc, &rhs_subsc,
-	   kind, data);
+	   kind, &data);
       else if (xmp_is_async() && xmpt_callback[xmpt_event_gmove_begin_async])
 	(*(xmpt_event_gmove_begin_async_t)xmpt_callback[xmpt_event_gmove_begin_async])
 	  (gmv_desc_leftp->a_desc, &lhs_subsc,
 	   gmv_desc_rightp->a_desc, &rhs_subsc,
-	   kind, async_id, data);
+	   kind, async_id, &data);
     }
 #endif
 
@@ -207,12 +207,12 @@ xmpc_gmv_do(_XMP_gmv_desc_t *gmv_desc_leftp, _XMP_gmv_desc_t *gmv_desc_rightp,
 	  (*(xmpt_event_gmove_begin_t)xmpt_callback[xmpt_event_gmove_begin])
 	    (gmv_desc_leftp->a_desc, &lhs_subsc,
 	     gmv_desc_rightp->a_desc, &rhs_subsc,
-	     kind, data);
+	     kind, &data);
 	else if (xmp_is_async() && xmpt_callback[xmpt_event_gmove_begin_async])
 	  (*(xmpt_event_gmove_begin_async_t)xmpt_callback[xmpt_event_gmove_begin_async])
 	    (gmv_desc_leftp->a_desc, &lhs_subsc,
 	     gmv_desc_rightp->a_desc, &rhs_subsc,
-	     kind, async_id, data);
+	     kind, async_id, &data);
       }
 #endif
 
@@ -241,12 +241,12 @@ xmpc_gmv_do(_XMP_gmv_desc_t *gmv_desc_leftp, _XMP_gmv_desc_t *gmv_desc_rightp,
 	  (*(xmpt_event_gmove_begin_t)xmpt_callback[xmpt_event_gmove_begin])
 	    (gmv_desc_leftp->a_desc, &lhs_subsc,
 	     gmv_desc_rightp->a_desc, &rhs_subsc,
-	     kind, data);
+	     kind, &data);
 	else if (xmp_is_async() && xmpt_callback[xmpt_event_gmove_begin_async])
 	  (*(xmpt_event_gmove_begin_async_t)xmpt_callback[xmpt_event_gmove_begin_async])
 	    (gmv_desc_leftp->a_desc, &lhs_subsc,
 	     gmv_desc_rightp->a_desc, &rhs_subsc,
-	     kind, async_id, data);
+	     kind, async_id, &data);
       }
 #endif
 
@@ -262,7 +262,7 @@ xmpc_gmv_do(_XMP_gmv_desc_t *gmv_desc_leftp, _XMP_gmv_desc_t *gmv_desc_rightp,
 #ifdef _XMPT
   if (xmpt_enabled && xmpt_callback[xmpt_event_gmove_end])
     (*(xmpt_event_end_t)xmpt_callback[xmpt_event_gmove_end])(
-     data);
+     &data);
 #endif
 
 }

--- a/libxmp/src/xmpc_task.c
+++ b/libxmp/src/xmpc_task.c
@@ -5,7 +5,7 @@ void xmpc_create_task_nodes(_XMP_nodes_t **n, _XMP_object_ref_t *r_desc)
   _XMP_create_task_nodes(n, r_desc);
 
 #ifdef _XMPT
-  xmpt_tool_data_t *data = (*n)->xmpt_data;
+  xmpt_tool_data_t *data = &((*n)->xmpt_data); *data=NULL;
   xmp_desc_t on = r_desc->ref_kind == XMP_OBJ_REF_NODES ?
     (xmp_desc_t)r_desc->n_desc : (xmp_desc_t)r_desc->t_desc;
   struct _xmpt_subscript_t on_subsc;
@@ -40,7 +40,7 @@ void xmpc_end_task(void)
 void xmpc_finalize_task_nodes(_XMP_nodes_t *n){
 
 #ifdef _XMPT
-  xmpt_tool_data_t *data = n->xmpt_data;
+  xmpt_tool_data_t *data = &(n->xmpt_data);
   if (xmpt_enabled && xmpt_callback[xmpt_event_task_end])
     (*(xmpt_event_end_t)xmpt_callback[xmpt_event_task_end])(data);
 #endif


### PR DESCRIPTION
The runtime/compiler generated code needs to provide storage of type xmpt_tool_data_t. 
The begin callback hands over the address to allow the tool to modify the value.
For symetry also the end callback provides the address.