### PR TITLE
Assignment to the result of the pointer function

### DIFF
--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -5459,7 +5459,6 @@ compile_procedure_declaration(expr x)
                 declare_id_type(interface, function_type(new_type_desc()));
                 ID_CLASS(interface) = CL_PROC;
                 declare_function(interface);
-
                 TYPE_SET_IMPLICIT(FUNCTION_TYPE_RETURN_TYPE(ID_TYPE(interface)));
                 TYPE_BASIC_TYPE(FUNCTION_TYPE_RETURN_TYPE(ID_TYPE(interface))) = TYPE_GENERIC;
             }

--- a/F-FrontEnd/test/failtestdata/function_result_ponter_without_declared_function.f90
+++ b/F-FrontEnd/test/failtestdata/function_result_ponter_without_declared_function.f90
@@ -1,0 +1,11 @@
+      module mod
+        real,target :: tmp
+       contains
+        subroutine sub()
+          real a
+          a = 3.0
+          print *, f(a)
+          f(a) = 6.0
+          print *, f(a)
+        end subroutine sub
+      end module mod

--- a/F-FrontEnd/test/testdata/function_result_pointer_1.f90
+++ b/F-FrontEnd/test/testdata/function_result_pointer_1.f90
@@ -1,0 +1,20 @@
+      module mod
+        real,target :: tmp
+       contains
+        function f(key) result(res)
+          real,intent(in) :: key
+          real,pointer :: res
+          tmp = key + 2.0
+          res => tmp
+        end function f
+      end module mod
+      !
+      program main
+        use mod
+        real a
+        a = 3.0
+        print *, f(a)
+        f(a) = 6.0   ! ポインタ関数結果に対して代入をする。
+        print *, f(a)
+      end program main
+

--- a/F-FrontEnd/test/testdata/function_result_pointer_2.f90
+++ b/F-FrontEnd/test/testdata/function_result_pointer_2.f90
@@ -1,0 +1,27 @@
+      module mod
+        real,target :: tmp
+       contains
+        subroutine sub()
+          real a
+          a = 3.0
+          print *, f(a)
+          f(a) = 6.0   ! ポインタ関数結果に対して代入をする。
+          print *, f(a)
+        end subroutine sub
+        function f(key) result(res)
+          real,intent(in) :: key
+          real,pointer :: res
+          tmp = key + 2.0
+          res => tmp
+        end function f
+      end module mod
+      !
+      program main
+        use mod
+        real a
+        a = 3.0
+        print *, f(a)
+        f(a) = 6.0   ! ポインタ関数結果に対して代入をする。
+        print *, f(a)
+      end program main
+


### PR DESCRIPTION
This pull-request will implement for the assignment to the result of the pointer function.

ex)
```
  module mod
    real,target :: tmp
   contains
    function f(key) result(res)
      real,intent(in) :: key
      real,pointer :: res
      tmp = key + 2.0
      res => tmp
    end function f
  end module mod
  !
  program main
      use mod
      real a
      a = 3.0
      print *, f(a)
      f(a) = 6.0   ! Assignment to the result of the pointer function
      print *, f(a)
  end program main
```