### PR TITLE
Fix detection of hollerith code. Fix for issue #192

### DIFF
--- a/F-FrontEnd/src/F95-lex.c
+++ b/F-FrontEnd/src/F95-lex.c
@@ -3769,7 +3769,7 @@ ScanFortranLine(src, srcHead, dst, dstHead, dstMax, inQuotePtr, quoteCharPtr,
                 cur = src;
                 --cur; // Char before the h/H
                 while (isdigit((int)*cur)) {
-                    cur--;
+                    --cur;
                 }
                 if(isalpha((int)*cur) || *cur == '_') {
                     goto copyOne;

--- a/F-FrontEnd/src/F95-lex.c
+++ b/F-FrontEnd/src/F95-lex.c
@@ -3739,6 +3739,7 @@ ScanFortranLine(src, srcHead, dst, dstHead, dstMax, inQuotePtr, quoteCharPtr,
      char **newDstPtr;
 {
     char *cpDst = dst;
+    char *cur;
 
     while (*src != '\0' && dst <= dstMax) {
         if (isspace((int)*src)) {
@@ -3762,9 +3763,21 @@ ScanFortranLine(src, srcHead, dst, dstHead, dstMax, inQuotePtr, quoteCharPtr,
             }
         } else if (*src == 'h' || *src == 'H') {
             if (*inHollerithPtr == FALSE && *inQuotePtr == FALSE) {
-                unHollerith(src, srcHead, dst, dstHead, dstMax,
-                            inQuotePtr, *quoteCharPtr,
-                            inHollerithPtr, hollerithLenPtr, &src, &dst);
+                /*
+                 * check backward if only digit before the H
+                 */
+                cur = src;
+                --cur; // Char before the h/H
+                while (isdigit((int)*cur)) {
+                    cur--;
+                }
+                if(isalpha((int)*cur) || *cur == '_') {
+                    goto copyOne;
+                } else {
+                    unHollerith(src, srcHead, dst, dstHead, dstMax,
+                                inQuotePtr, *quoteCharPtr,
+                                inHollerithPtr, hollerithLenPtr, &src, &dst);
+                }
             } else {
                 goto copyOne;
             }


### PR DESCRIPTION
#192 

I think the Hollerith constant detection should even be removed from the lexer as it has been removed from the Fortran 95 standard. 