### PR TITLE
Fix #221

### DIFF
--- a/F-FrontEnd/src/C-expr-mem.c
+++ b/F-FrontEnd/src/C-expr-mem.c
@@ -266,10 +266,14 @@ list_delete_item(lx, x)
     }
     if (lp != NULL) {
         if (lp == first) {
-            struct list_node *l = (struct list_node *)malloc(sizeof(struct list_node));
-            memcpy(l, LIST_NEXT(lp), sizeof(struct list_node));
-            LIST_NEXT(lp) = NULL;
-            EXPR_LIST(lx) = l;
+            if (LIST_NEXT(lp)) {
+                struct list_node *l = (struct list_node *)malloc(sizeof(struct list_node));
+                memcpy(l, LIST_NEXT(lp), sizeof(struct list_node));
+                LIST_NEXT(lp) = NULL;
+                EXPR_LIST(lx) = l;
+            } else {
+                return NULL;
+            }
         } else {
             LIST_NEXT(oLp) = LIST_NEXT(lp);
             LIST_NEXT(lp) = NULL;

--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -16,6 +16,7 @@ static void     declare_dummy_args _ANSI_ARGS_((expr l,
                                                 enum name_class class));
 static int      markAsSave _ANSI_ARGS_((ID id));
 
+
 /* for module and use statement */
 extern char line_buffer[];
 extern SYMBOL current_module_name;

--- a/F-FrontEnd/src/F95-parser.y
+++ b/F-FrontEnd/src/F95-parser.y
@@ -680,15 +680,9 @@ statement:      /* entry */
 
 /* FUNCTION declaration */
         | FUNCTION IDENTIFIER dummy_arg_list KW func_suffix
-          { $$ = list6(F_FUNCTION_STATEMENT, $2, $3, NULL, NULL, EXPR_ARG1($5), EXPR_ARG2($5)); }
+          { $$ = list5(F_FUNCTION_STATEMENT, $2, $3, NULL, EXPR_ARG1($5), EXPR_ARG2($5)); }
         | func_prefix FUNCTION IDENTIFIER dummy_arg_list KW func_suffix
-          { $$ = list6(F_FUNCTION_STATEMENT, $3, $4, NULL, $1, EXPR_ARG1($6), EXPR_ARG2($6)); }
-        | type_spec KW FUNCTION IDENTIFIER dummy_arg_list KW func_suffix
-          { $$ = list6(F_FUNCTION_STATEMENT, $4, $5, $1, NULL, EXPR_ARG1($7), EXPR_ARG2($7)); }
-        | type_spec KW func_prefix FUNCTION IDENTIFIER dummy_arg_list KW func_suffix
-          { $$ = list6(F_FUNCTION_STATEMENT, $5, $6, $1, $3, EXPR_ARG1($8), EXPR_ARG2($8)); }
-        | func_prefix type_spec KW FUNCTION IDENTIFIER dummy_arg_list KW func_suffix
-          { $$ = list6(F_FUNCTION_STATEMENT, $5, $6, $2, $1, EXPR_ARG1($8), EXPR_ARG2($8)); }
+          { $$ = list5(F_FUNCTION_STATEMENT, $3, $4, $1, EXPR_ARG1($6), EXPR_ARG2($6)); }
 /* END: FUNCTION */
         | ENDFUNCTION name_or_null
           { $$ = list1(F95_ENDFUNCTION_STATEMENT,$2); }
@@ -938,6 +932,7 @@ prefix_spec:
         { $$ = list0(F95_ELEMENTAL_SPEC); }
         | MODULE
         { $$ = list0(F08_MODULE_SPEC); }
+        | type_spec
         ;
 
 name:  IDENTIFIER;

--- a/F-FrontEnd/test/testdata/function_with_prefixes.f90
+++ b/F-FrontEnd/test/testdata/function_with_prefixes.f90
@@ -1,21 +1,49 @@
-      ELEMENTAL INTEGER PURE FUNCTION k(a)
-        INTENT(IN) :: a
-      END FUNCTION
+      MODULE mod
+        TYPE function
+          INTEGER :: v
+        END TYPE function
+       CONTAINS
+        FUNCTION f(a)
+        END FUNCTION f
 
-      INTEGER ELEMENTAL FUNCTION j(a)
-        INTENT(IN) :: a
-      END FUNCTION
+        ELEMENTAL FUNCTION g(a)
+          INTENT(IN) :: a
+        END FUNCTION g
 
-      ELEMENTAL INTEGER FUNCTION i(a)
-        INTENT(IN) :: a
-      END FUNCTION
+        INTEGER FUNCTION h(a)
+        END FUNCTION
 
-      INTEGER FUNCTION h(a)
-      END FUNCTION
+        ELEMENTAL INTEGER FUNCTION i(a)
+          INTENT(IN) :: a
+        END FUNCTION
 
-      ELEMENTAL FUNCTION g(a)
-        INTENT(IN) :: a
-      END FUNCTION g
+        INTEGER ELEMENTAL FUNCTION j(a)
+          INTENT(IN) :: a
+        END FUNCTION
 
-      FUNCTION f(a)
-      END FUNCTION f
+        ELEMENTAL INTEGER PURE FUNCTION k(a)
+          INTENT(IN) :: a
+        END FUNCTION
+
+        ELEMENTAL PURE INTEGER FUNCTION l(a)
+          INTENT(IN) :: a
+        END FUNCTION
+
+        ELEMENTAL PURE INTEGER FUNCTION m(a)
+          INTENT(IN) :: a
+        END FUNCTION
+
+        TYPE(function) FUNCTION n(a)
+          INTEGER :: a
+        END FUNCTION
+
+        ELEMENTAL TYPE(function) FUNCTION o(a)
+          INTENT(IN) :: a
+        END FUNCTION
+
+        TYPE(function) ELEMENTAL FUNCTION p(a)
+          INTENT(IN) :: a
+        END FUNCTION
+      END MODULE mod
+
+      PROGRAM main; USE mod; END PROGRAM main

--- a/F-FrontEnd/test/testdata/function_with_prefixes.f90
+++ b/F-FrontEnd/test/testdata/function_with_prefixes.f90
@@ -1,0 +1,21 @@
+      ELEMENTAL INTEGER PURE FUNCTION k(a)
+        INTENT(IN) :: a
+      END FUNCTION
+
+      INTEGER ELEMENTAL FUNCTION j(a)
+        INTENT(IN) :: a
+      END FUNCTION
+
+      ELEMENTAL INTEGER FUNCTION i(a)
+        INTENT(IN) :: a
+      END FUNCTION
+
+      INTEGER FUNCTION h(a)
+      END FUNCTION
+
+      ELEMENTAL FUNCTION g(a)
+        INTENT(IN) :: a
+      END FUNCTION g
+
+      FUNCTION f(a)
+      END FUNCTION f


### PR DESCRIPTION
Accept function prefixes in any order like:

```fortran
    ELEMENTAL INTEGER FUNCTION f(a)
      ...
    END FUNCTION

    INTEGER ELEMENTAL FUNCTION f(a)
      ...
    END FUNCTION


    ELEMENTAL INTEGER IMPURE FUNCTION f(a)
      ...
    END FUNCTION

```