### PR TITLE
Fix visibility in INTERFACE construct

### DIFF
--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -1727,6 +1727,22 @@ find_external_cont_ident_head(SYMBOL s)
     return NULL;
 }
 
+static int
+in_interface()
+{
+    int i;
+    CTL cp;
+    FOR_CTLS_BACKWARD(cp) {
+        if (CTL_TYPE(cp) == CTL_INTERFACE)
+            return TRUE;
+    }
+    for (i = 0; i < unit_ctl_level; i++) {
+        if (UNIT_CTL_CURRENT_STATE(unit_ctls[i]) == ININTR)
+            return TRUE;
+    }
+    return FALSE;
+}
+
 
 /*
  * Find an identifier from the outiside of the current scope.
@@ -1764,6 +1780,9 @@ find_ident(SYMBOL s)
     ip = find_ident_local(s);
     if (ip != NULL) {
         return ip;
+    }
+    if (in_interface()) {
+        return NULL;
     }
     return find_ident_outer_scope(s);
 }
@@ -3862,6 +3881,9 @@ find_struct_decl(SYMBOL s)
     tp = find_struct_decl_head(s, LOCAL_STRUCT_DECLS);
     if (tp != NULL) {
         return tp;
+    }
+    if (in_interface()) {
+        return NULL;
     }
     tp = find_struct_decl_block_parent(s);
     if (tp != NULL) {

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -1760,7 +1760,6 @@ inblock()
     return FALSE;
 }
 
-
 void
 check_NOT_INBLOCK()
 {

--- a/F-FrontEnd/src/F-ident.h
+++ b/F-FrontEnd/src/F-ident.h
@@ -164,6 +164,7 @@ typedef struct ident_descriptor
                                            of this ID, otherwise
                                            NULL */
     int from_parent_module;             /* ID is imported from parent module  */
+    int imported;                       /* ID imported with the IMPORT statement */
 
     union {
         struct {
@@ -283,6 +284,10 @@ typedef struct ident_descriptor
 #define ID_LINE(id)     ((id)->line)
 #define ID_ORDER(id)    ((id)->order)
 #define ID_DEFINED_BY(id)       ((id)->defined_by)
+
+#define ID_IS_IMPORTED(id)       ((id)->imported)
+#define ID_SET_IMPORTED(id)      ((id)->imported = TRUE)
+#define ID_UNSET_IMPORTED(id)    ((id)->imported = FALSE)
 
 #define ID_INTF(id)     ((id)->interfaceId)
 

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -4989,6 +4989,9 @@ emit_decl(int l, ID id)
     if (ID_IS_OFMODULE(id) == TRUE && ID_CLASS(id) != CL_PARAM) {
         return;
     }
+    if (ID_IS_IMPORTED(id)) {
+        return;
+    }
 
     if (CRT_FUNCEP != NULL && EXT_PROC_IS_PROCEDUREDECL(CRT_FUNCEP)) {
         /*
@@ -5100,6 +5103,10 @@ outx_id_declarations(int l, ID id_list, int hasResultVar, const char * functionN
             }
 
             if (TYPE_IS_MODIFIED(ID_TYPE(id)) == TRUE) {
+                continue;
+            }
+
+            if (ID_IS_IMPORTED(id) == TRUE) {
                 continue;
             }
 

--- a/F-FrontEnd/test/testdata/submodule_3.f90
+++ b/F-FrontEnd/test/testdata/submodule_3.f90
@@ -5,6 +5,7 @@
 
         INTERFACE
            MODULE FUNCTION point_dist(a, b) RESULT(distance)
+             IMPORT POINT
              TYPE(POINT), INTENT(IN) :: a, b
              REAL :: distance
            END FUNCTION point_dist


### PR DESCRIPTION
This pull-request will fix the visibility in the INTERFACE construct.

From INTERFACE construct, identifiers in the outer scope shold not be visibile without IMPORT statement。.