### PR TITLE
Avoid generating return type in case of external subroutine (Fix #268)

### DIFF
--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -4612,7 +4612,7 @@ compile_EXTERNAL_decl(expr id_list)
 {
     list lp;
     expr ident;
-    ID id;
+    ID id, parentid;
 
     if (id_list == NULL) {
         return; /* error */
@@ -4633,7 +4633,16 @@ compile_EXTERNAL_decl(expr id_list)
             if (ID_TYPE(id) != NULL && !IS_PROCEDURE_TYPE(ID_TYPE(id))) {
                 ID_TYPE(id) = function_type(ID_TYPE(id));
             }
-
+            parentid = find_ident_parent(EXPR_SYM(ident));
+            if(parentid != NULL) {
+                if(ID_TYPE(parentid) != NULL && 
+                    TYPE_BASIC_TYPE(ID_TYPE(parentid)) == TYPE_SUBR)
+                {
+                    /* Force void for SUBROUTINE, otherwise standard compiler 
+                     * will fails */
+                    ID_TYPE(id) = type_VOID;
+                }
+            }
             TYPE_SET_EXTERNAL(id);
         } else if (PROC_CLASS(id) != P_EXTERNAL) {
             error_at_node(id_list,

--- a/F-FrontEnd/test/testdata/issue268.f90
+++ b/F-FrontEnd/test/testdata/issue268.f90
@@ -1,0 +1,17 @@
+module mod1
+contains
+  subroutine sub1()
+  end subroutine
+
+  function fct1()
+    real :: fct1
+  end function
+
+  subroutine sub2(sub1, fct1)
+    external sub1, fct1
+  end subroutine sub2
+
+  subroutine sub3()
+    call sub2(sub1, fct1)
+  end subroutine sub3
+end module mod1


### PR DESCRIPTION
Fix for issue #268 