### PR TITLE
reference the part of complex value

### DIFF
--- a/F-BackEnd/src/xcodeml/f/decompile/XfDecompileDomVisitor.java
+++ b/F-BackEnd/src/xcodeml/f/decompile/XfDecompileDomVisitor.java
@@ -2517,6 +2517,19 @@ public class XfDecompileDomVisitor {
         }
     }
 
+    // FcomplexPartRef
+    class FcomplexPartRefVisitor extends XcodeNodeVisitor {
+        /**
+         * Decompile "FcomplexPartRef" element in XcodeML/F.
+         */
+        @Override public void enter(Node n) {
+            invokeEnter(XmDomUtil.getElement(n, "varRef"));
+            XmfWriter writer = _context.getWriter();
+            writer.writeToken("%");
+            writer.writeToken(XmDomUtil.getAttr(n, "part"));
+        }
+    }
+
     // FconcatExpr
     class FconcatExprVisitor extends XcodeNodeVisitor {
         /**
@@ -7157,6 +7170,7 @@ public class XfDecompileDomVisitor {
         new Pair("FcloseStatement", new FcloseStatementVisitor()),
         new Pair("FcommonDecl", new FcommonDeclVisitor()),
         new Pair("FcomplexConstant", new FcomplexConstantVisitor()),
+        new Pair("FcomplexPartRef", new FcomplexPartRefVisitor()),
         new Pair("FconcatExpr", new FconcatExprVisitor()),
         new Pair("FcontainsStatement", new FcontainsStatementVisitor()),
         new Pair("FcycleStatement", new FcycleStatementVisitor()),

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -6029,6 +6029,30 @@ compile_set_expr(expr x) {
 }
 
 
+static expv
+compile_complex_member_ref(expv cmplx, expr mem)
+{
+    TYPE_DESC tp;
+    expv v;
+
+    if (strcmp("re", SYM_NAME(EXPR_SYM(mem))) != 0  &&
+        strcmp("im", SYM_NAME(EXPR_SYM(mem))) != 0) {
+        error("COMPLEX has no member '%s'", SYM_NAME(EXPR_SYM(mem)));
+        return NULL;
+    }
+
+    if (TYPE_HAVE_KIND(EXPV_TYPE(cmplx))) {
+        tp = wrap_type(type_REAL);
+        TYPE_KIND(tp) = TYPE_KIND(EXPV_TYPE(cmplx));
+    } else {
+        tp = type_REAL;
+    }
+
+    v = expv_cons(F95_MEMBER_REF, tp, cmplx, mem);
+    EXPV_LINE(v) = EXPR_LINE(mem);
+    return v;
+}
+
 expv
 compile_member_ref(expr x)
 {
@@ -6059,7 +6083,7 @@ compile_member_ref(expr x)
 
     stVTyp = EXPV_TYPE(struct_v);
 
-    if(IS_ARRAY_TYPE(stVTyp)) {
+    if (IS_ARRAY_TYPE(stVTyp)) {
         shape = list0(LIST);
         generate_shape_expr(EXPV_TYPE(struct_v), shape);
         stVTyp = bottom_type(stVTyp);
@@ -6067,6 +6091,10 @@ compile_member_ref(expr x)
 
     mX = EXPR_ARG2(x);
     assert(EXPR_CODE(mX) == IDENT);
+
+    if (IS_COMPLEX(stVTyp)) {
+        return compile_complex_member_ref(struct_v, mX);
+    }
 
     member_id = find_struct_member(stVTyp, EXPR_SYM(mX));
 
@@ -6122,7 +6150,7 @@ compile_member_ref(expr x)
         }
 
         tp = retTyp;
-	tp = compile_dimensions(tp, shape);
+        tp = compile_dimensions(tp, shape);
     } else {
         tp = ID_TYPE(member_id);
 

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -2255,7 +2255,9 @@ outx_memberRef(int l, expv v)
     expv v_right = EXPV_RIGHT(v);
 
     outx_typeAttrOnly_EXPR(l, v, XTAG(v));
-    outx_print(" member=\"%s\">\n", SYM_NAME(EXPV_NAME(v_right)));
+    outx_print(" member=\"%s\"", SYM_NAME(EXPV_NAME(v_right)));
+    outx_true(IS_COMPLEX(EXPV_TYPE(v_left)), "is_complex_part");
+    outx_print(">\n");
     outx_varRef_EXPR(l + 1, v_left);
     outx_expvClose(l, v);
 }

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -2246,6 +2246,23 @@ outx_characterRef(int l, expv v)
 
 
 /**
+ * output FcomplexPartRef
+ */
+static void
+outx_complexPartRef(int l, expv v)
+{
+    expv v_left = EXPV_LEFT(v);
+    expv v_right = EXPV_RIGHT(v);
+
+    outx_typeAttrOnly_EXPR(l, v, "FcomplexPartRef");
+    outx_print(" part=\"%s\"", SYM_NAME(EXPV_NAME(v_right)));
+    outx_print(">\n");
+    outx_varRef_EXPR(l + 1, v_left);
+    outx_close(l, "FcomplexPartRef");
+}
+
+
+/**
  * output FmemberRef
  */
 static void
@@ -2254,9 +2271,11 @@ outx_memberRef(int l, expv v)
     expv v_left = EXPV_LEFT(v);
     expv v_right = EXPV_RIGHT(v);
 
+    if (IS_COMPLEX(EXPV_TYPE(v_left)))
+        return outx_complexPartRef(l, v);
+
     outx_typeAttrOnly_EXPR(l, v, XTAG(v));
     outx_print(" member=\"%s\"", SYM_NAME(EXPV_NAME(v_right)));
-    outx_true(IS_COMPLEX(EXPV_TYPE(v_left)), "is_complex_part");
     outx_print(">\n");
     outx_varRef_EXPR(l + 1, v_left);
     outx_expvClose(l, v);

--- a/F-FrontEnd/test/testdata/complex_member_ref.f08
+++ b/F-FrontEnd/test/testdata/complex_member_ref.f08
@@ -1,0 +1,7 @@
+      PROGRAM main
+        COMPLEX :: a
+        a%RE = 1.0
+        a%IM = 2.0
+        PRINT *, a%RE
+        PRINT *, a%IM
+      END PROGRAM main


### PR DESCRIPTION
This pull request will implement referencing the part of complex value

```fortran
    COMPLEX :: a
    a%RE = 1.0
    a%IM = 2.0
```