### PR TITLE
Fix #248

### DIFF
--- a/F-FrontEnd/src/F95-parser.y
+++ b/F-FrontEnd/src/F95-parser.y
@@ -1773,8 +1773,6 @@ executable_statement:
 	 CTL_WHERE/CTL_ELSE_WHERE and treat coming statement
 	 appropriately.
 	 ***/
-        | WHERE '(' expr ')' assign_statement_or_null
-        { $$ = list2(F_WHERE_STATEMENT,$3,$5); }
         | ELSEWHERE
         { $$ = list0(F_ELSEWHERE_STATEMENT); }
         | ELSEWHERE '(' expr ')' assign_statement_or_null


### PR DESCRIPTION
This pull-request will remove one reduce/reduce confilict.

(Just remove duplicate `WHERE '(' expr ')' assign_statement_or_null`)