### PR TITLE
 Fix syntax error for type-bound GENERIC statement with access-spec (Fix #314)

### DIFF
--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -5899,39 +5899,35 @@ compile_type_bound_generic_procedure(expr x)
     }
 
     if (access_attr) {
-        FOR_ITEMS_IN_LIST(lp, access_attr) {
-            expr v = LIST_ITEM(lp);
-            switch (EXPR_CODE(v)) {
-
-                /*
-                 * Accesss specs
-                 */
-                case F95_PUBLIC_SPEC:
-                    if (access_attr_flags & TYPE_ATTR_PUBLIC) {
-                        error_at_node(x, "PUBLIC is already specified.");
-                        return;
-                    }
-                    if (access_attr_flags & (TYPE_ATTR_PRIVATE)) {
-                        error_at_node(x, "access specs are conflicted.");
-                        return;
-                    }
-                    access_attr_flags |= TYPE_ATTR_PUBLIC;
-                    break;
-                case F95_PRIVATE_SPEC:
-                    if (access_attr_flags & TYPE_ATTR_PRIVATE) {
-                        error_at_node(x, "PRIVATE is already specified.");
-                        return;
-                    }
-                    if (access_attr_flags & (TYPE_ATTR_PUBLIC)) {
-                        error_at_node(x, "access specs are conflicted.");
-                        return;
-                    }
-                    access_attr_flags |= TYPE_ATTR_PRIVATE;
-                    break;
-                default:
-                    error_at_node(x, "unexpected expression");
-                    break;
-            }
+        switch (EXPR_CODE(access_attr)) {
+            /*
+             * Accesss specs
+             */
+            case F95_PUBLIC_SPEC:
+                if (access_attr_flags & TYPE_ATTR_PUBLIC) {
+                    error_at_node(x, "PUBLIC is already specified.");
+                    return;
+                }
+                if (access_attr_flags & (TYPE_ATTR_PRIVATE)) {
+                    error_at_node(x, "access specs are conflicted.");
+                    return;
+                }
+                access_attr_flags |= TYPE_ATTR_PUBLIC;
+                break;
+            case F95_PRIVATE_SPEC:
+                if (access_attr_flags & TYPE_ATTR_PRIVATE) {
+                    error_at_node(x, "PRIVATE is already specified.");
+                    return;
+                }
+                if (access_attr_flags & (TYPE_ATTR_PUBLIC)) {
+                    error_at_node(x, "access specs are conflicted.");
+                    return;
+                }
+                access_attr_flags |= TYPE_ATTR_PRIVATE;
+                break;
+            default:
+                error_at_node(x, "unexpected expression");
+            break;
         }
     } else if (is_internal_private) {
         access_attr_flags |= TYPE_ATTR_PRIVATE;

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -4632,6 +4632,8 @@ outx_structType(int l, TYPE_DESC tp)
                     }
                     outx_puts("\" ");
                 }
+                outx_true(TYPE_IS_PUBLIC(id), "is_public");
+                outx_true(TYPE_IS_PRIVATE(id), "is_private");
                 outx_printi(0,">\n");
                 if (!is_defined_io) {
                     outx_tagText(l3, "name", SYM_NAME(ID_SYM(id)));

--- a/F-FrontEnd/src/F95-parser.y
+++ b/F-FrontEnd/src/F95-parser.y
@@ -661,8 +661,8 @@ statement:      /* entry */
           { $$ = list1(F08_ENDPROCEDURE_STATEMENT, $2); }
         | GENERIC COL2 type_bound_generic_spec REF_OP ident_list
           { $$ = list3(F03_TYPE_BOUND_GENERIC_STATEMENT,$3, $5, NULL); }
-        | GENERIC ',' private_or_public_spec COL2 type_bound_generic_spec REF_OP ident_list
-          { $$ = list3(F03_TYPE_BOUND_GENERIC_STATEMENT,$5, $7, $3); }
+        | GENERIC ',' KW private_or_public_spec COL2 type_bound_generic_spec REF_OP ident_list
+         { $$ = list3(F03_TYPE_BOUND_GENERIC_STATEMENT, $6, $8, $4); }
         | FINAL COL2_or_null ident_list
           { $$ = list1(F03_TYPE_BOUND_FINAL_STATEMENT, $3); }
         | BLOCKDATA program_name

--- a/F-FrontEnd/test/testdata/issue314.f90
+++ b/F-FrontEnd/test/testdata/issue314.f90
@@ -1,0 +1,15 @@
+module abstract_m
+  type typ1
+  contains
+    procedure, private :: assign0
+    generic :: dummy => assign0
+    generic, public :: assign => assign0
+  end type
+  interface
+    subroutine assign0(this)
+      import typ1
+      class(typ1) ,intent(in) :: this
+    end subroutine
+  end interface
+end module
+

--- a/F-FrontEnd/test/testdata/issue314.f90
+++ b/F-FrontEnd/test/testdata/issue314.f90
@@ -4,6 +4,7 @@ module abstract_m
     procedure, private :: assign0
     generic :: dummy => assign0
     generic, public :: assign => assign0
+    generic, private :: assignp => assign0
   end type
   interface
     subroutine assign0(this)


### PR DESCRIPTION
Fix for #314 