### PR TITLE
Recover correct return type for external type bound procedure call (Fix #319)

### DIFF
--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -3294,6 +3294,13 @@ compile_type_bound_procedure_call(expv memberRef, expr args) {
             }
 #endif
             if (TYPE_REF(ftp)) {
+                if(FUNCTION_TYPE_RETURN_TYPE(TYPE_REF(ftp)) == NULL){ 
+                    // might have some ref indirection before getting to the 
+                    // actual function type
+                    while(TYPE_REF(TYPE_REF(ftp))) {
+                        ftp = TYPE_REF(ftp);
+                    }
+                } 
                 ret_type = FUNCTION_TYPE_RETURN_TYPE(TYPE_REF(ftp));
             } else {
                 /*

--- a/F-FrontEnd/test/testdata/_issue319.f90
+++ b/F-FrontEnd/test/testdata/_issue319.f90
@@ -1,0 +1,17 @@
+module issue319
+
+  public :: main
+
+  type typ1
+    contains
+      procedure, nopass, public :: id    
+  end type typ1
+
+  type(typ1), save :: main
+
+contains
+  function id()
+    integer :: id
+  end function id
+
+end module issue319

--- a/F-FrontEnd/test/testdata/issue319.f90
+++ b/F-FrontEnd/test/testdata/issue319.f90
@@ -1,12 +1,12 @@
 module mod1
-implicit none
 use issue319
+implicit none
 contains
   
 
-  subroutine sub1()
-    if(main%id() + 1 == 10) then 
+  subroutine sub2()
+    if(main%id() == 10) then 
     end if
-  end subroutine sub1
+  end subroutine sub2
 
 end module mod1

--- a/F-FrontEnd/test/testdata/issue319.f90
+++ b/F-FrontEnd/test/testdata/issue319.f90
@@ -1,0 +1,12 @@
+module mod1
+implicit none
+use issue319
+contains
+  
+
+  subroutine sub1()
+    if(main%id() + 1 == 10) then 
+    end if
+  end subroutine sub1
+
+end module mod1


### PR DESCRIPTION
Fix #319 