### PR TITLE
improve arguments of intrinsic procedures

### DIFF
--- a/F-FrontEnd/src/F-intrinsic.c
+++ b/F-FrontEnd/src/F-intrinsic.c
@@ -1236,7 +1236,6 @@ get_intrinsic_return_type(intrinsic_entry *ep, expv args, expv kindV) {
                             fix_array_dimensions(first);
                             return first;
                         }
-                        /* fall through */
 
                   return_assumed_shape:
                         /*

--- a/F-FrontEnd/src/F-intrinsics-table.c
+++ b/F-FrontEnd/src/F-intrinsics-table.c
@@ -80,6 +80,7 @@ intrinsic_entry intrinsic_table[] = {
 
     // MAX (A1, A2 [, A3,...])
     { INTR_MAX,         INTR_NAME_GENERIC,      "max",          0,      {INTR_TYPE_NUMERICS},                   INTR_TYPE_NUMERICS,  -1, 0, LANGSPEC_F77, INTR_CLASS_E },
+    { INTR_MAX,         INTR_NAME_GENERIC,      "",             0,      {INTR_TYPE_CHAR},                       INTR_TYPE_CHAR,      -1, 0, LANGSPEC_F2003, INTR_CLASS_E },
 
     { INTR_MAX,         INTR_NAME_SPECIFIC_NA,  "max0",         0,      {INTR_TYPE_INT},                        INTR_TYPE_INT,  -1, 0, LANGSPEC_F77, INTR_CLASS_E },
     { INTR_MAX,         INTR_NAME_SPECIFIC_NA,  "amax1",        0,      {INTR_TYPE_REAL},                       INTR_TYPE_REAL, -1, 0, LANGSPEC_F77, INTR_CLASS_E },
@@ -89,6 +90,7 @@ intrinsic_entry intrinsic_table[] = {
 
     // MIN (A1, A2 [, A3,...])
     { INTR_MIN,         INTR_NAME_GENERIC,      "min",          0,      {INTR_TYPE_NUMERICS},                   INTR_TYPE_NUMERICS,  -1, 0, LANGSPEC_F77, INTR_CLASS_E },
+    { INTR_MIN,         INTR_NAME_GENERIC,      "",             0,      {INTR_TYPE_CHAR},                       INTR_TYPE_CHAR,      -1, 0, LANGSPEC_F2003, INTR_CLASS_E },
 
     { INTR_MIN,         INTR_NAME_SPECIFIC_NA,  "min0",         0,      {INTR_TYPE_INT},                        INTR_TYPE_INT,  -1, 0, LANGSPEC_F77, INTR_CLASS_E },
     { INTR_MIN,         INTR_NAME_SPECIFIC_NA,  "amin1",        0,      {INTR_TYPE_REAL},                       INTR_TYPE_REAL, -1, 0, LANGSPEC_F77, INTR_CLASS_E },
@@ -514,9 +516,11 @@ intrinsic_entry intrinsic_table[] = {
     // MINVAL (ARRAY [, MASK])
     { INTR_MINVAL,      INTR_NAME_GENERIC,      "minval",       0,      { INTR_TYPE_NUMERICS_ARRAY },                           INTR_TYPE_NUMERICS,             1, -2, LANGSPEC_F90, INTR_CLASS_T },
     { INTR_MINVAL,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_NUMERICS_ARRAY,  INTR_TYPE_LOGICAL_ARRAY }, INTR_TYPE_NUMERICS,             2, -2, LANGSPEC_F90, INTR_CLASS_T },
+    { INTR_MINVAL,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY,      INTR_TYPE_LOGICAL_ARRAY }, INTR_TYPE_NUMERICS,             2, -2, LANGSPEC_F2003, INTR_CLASS_T },
     // MINVAL (ARRAY, DIM [, MASK])
     { INTR_MINVAL,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_NUMERICS_ARRAY, INTR_TYPE_INT },                            INTR_TYPE_NUMERICS_DYNAMIC_ARRAY,       2, -1, LANGSPEC_F90, INTR_CLASS_T },
     { INTR_MINVAL,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_NUMERICS_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY },   INTR_TYPE_NUMERICS_DYNAMIC_ARRAY,       3, -1, LANGSPEC_F90, INTR_CLASS_T },
+    { INTR_MINVAL,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY,     INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY },   INTR_TYPE_NUMERICS_DYNAMIC_ARRAY,       3, -1, LANGSPEC_F2003, INTR_CLASS_T },
 
     // PRODUCT (ARRAY [, MASK])
     { INTR_PRODUCT,     INTR_NAME_GENERIC,      "product",      0,      { INTR_TYPE_ALL_NUMERICS_ARRAY },                               INTR_TYPE_ALL_NUMERICS,         1, -2, LANGSPEC_F90, INTR_CLASS_T },
@@ -603,33 +607,75 @@ intrinsic_entry intrinsic_table[] = {
 
     /* 19. Array location functions */
 
-    // MINLOC (ARRAY [, MASK, KIND])
-    { INTR_MINLOC,      INTR_NAME_GENERIC,      "minloc",       1,      { INTR_TYPE_INT_ARRAY },                                INTR_TYPE_INT_ARRAY,    1, -3, LANGSPEC_F90, INTR_CLASS_T },
-    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_ALL_REAL_ARRAY },                           INTR_TYPE_INT_ARRAY,    1, -3, LANGSPEC_F90, INTR_CLASS_T },
-    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_LOGICAL_ARRAY },       INTR_TYPE_INT_ARRAY,    2, -3, LANGSPEC_F90, INTR_CLASS_T },
-    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_LOGICAL_ARRAY },  INTR_TYPE_INT_ARRAY,    2, -3, LANGSPEC_F90, INTR_CLASS_T },
+    // MINLOC (ARRAY [, MASK, KIND, BACK])
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "minloc",       0,      { INTR_TYPE_INT_ARRAY },                                                                  INTR_TYPE_INT_ARRAY,    1, -3, LANGSPEC_F90, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_LOGICAL_ARRAY },                                         INTR_TYPE_INT_ARRAY,    2, -3, LANGSPEC_F90, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },                          INTR_TYPE_INT_ARRAY,    3, -3, LANGSPEC_F90, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL },       INTR_TYPE_INT_ARRAY,    4, -3, LANGSPEC_F90, INTR_CLASS_T },
 
-    // MINLOC (ARRAY [, DIM, MASK, KIND]) (Fortran 95)
-    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_INT },       INTR_TYPE_INT_ARRAY,    2, -3, LANGSPEC_F95, INTR_CLASS_T },
-    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_INT },  INTR_TYPE_INT_ARRAY,    2, -3, LANGSPEC_F95, INTR_CLASS_T },
-    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },       INTR_TYPE_INT_ARRAY,    3, -3, LANGSPEC_F95, INTR_CLASS_T },
-    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY },       INTR_TYPE_INT_ARRAY,    3, -3, LANGSPEC_F95, INTR_CLASS_T },
-    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },  INTR_TYPE_INT_ARRAY,    3, -3, LANGSPEC_F95, INTR_CLASS_T },
-    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY },  INTR_TYPE_INT_ARRAY,    3, -3, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY },                                                             INTR_TYPE_INT_ARRAY,    1, -3, LANGSPEC_F90, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_LOGICAL_ARRAY },                                    INTR_TYPE_INT_ARRAY,    2, -3, LANGSPEC_F90, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },                     INTR_TYPE_INT_ARRAY,    3, -3, LANGSPEC_F90, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL },  INTR_TYPE_INT_ARRAY,    4, -3, LANGSPEC_F90, INTR_CLASS_T },
 
-    // MAXLOC (ARRAY [, MASK, KIND])
-    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "maxloc",       1,      { INTR_TYPE_INT_ARRAY },                                INTR_TYPE_INT_ARRAY,    1, -3, LANGSPEC_F90, INTR_CLASS_T },
-    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_ALL_REAL_ARRAY },                           INTR_TYPE_INT_ARRAY,    1, -3, LANGSPEC_F90, INTR_CLASS_T },
-    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_LOGICAL_ARRAY },       INTR_TYPE_INT_ARRAY,    2, -3, LANGSPEC_F90, INTR_CLASS_T },
-    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_LOGICAL_ARRAY },  INTR_TYPE_INT_ARRAY,    2, -3, LANGSPEC_F90, INTR_CLASS_T },
+    //// F2003 accepts CHARACTER ARRAY
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY },                                                                 INTR_TYPE_INT_ARRAY,    1, -3, LANGSPEC_F2003, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY, INTR_TYPE_LOGICAL_ARRAY },                                        INTR_TYPE_INT_ARRAY,    2, -3, LANGSPEC_F2003, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },                         INTR_TYPE_INT_ARRAY,    3, -3, LANGSPEC_F2003, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL },      INTR_TYPE_INT_ARRAY,    4, -3, LANGSPEC_F2003, INTR_CLASS_T },
 
-    // MAXLOC (ARRAY [, DIM, MASK, KIND]) (Fortran 95)
-    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_INT },       INTR_TYPE_INT_ARRAY,    2, -3, LANGSPEC_F95, INTR_CLASS_T },
-    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_INT },  INTR_TYPE_INT_ARRAY,    2, -3, LANGSPEC_F95, INTR_CLASS_T },
-    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },       INTR_TYPE_INT_ARRAY,    3, -3, LANGSPEC_F95, INTR_CLASS_T },
-    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY },       INTR_TYPE_INT_ARRAY,    3, -3, LANGSPEC_F95, INTR_CLASS_T },
-    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },  INTR_TYPE_INT_ARRAY,    3, -3, LANGSPEC_F95, INTR_CLASS_T },
-    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             1,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY },  INTR_TYPE_INT_ARRAY,    3, -3, LANGSPEC_F95, INTR_CLASS_T },
+    // MINLOC (ARRAY, DIM [, MASK, KIND, BACK]) (Fortran 95)
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_INT },                                                   INTR_TYPE_INT_DYNAMIC_ARRAY,    2, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY },                          INTR_TYPE_INT_DYNAMIC_ARRAY,    3, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },           INTR_TYPE_INT_DYNAMIC_ARRAY,    4, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL },   INTR_TYPE_INT_DYNAMIC_ARRAY,    5, -1, LANGSPEC_F95, INTR_CLASS_T },
+
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_INT },                                              INTR_TYPE_INT_DYNAMIC_ARRAY,    2, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY },                     INTR_TYPE_INT_DYNAMIC_ARRAY,    3, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },      INTR_TYPE_INT_DYNAMIC_ARRAY,    4, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL }, INTR_TYPE_INT_DYNAMIC_ARRAY,    5, -1, LANGSPEC_F95, INTR_CLASS_T },
+
+    //// F2003 accepts CHARACTER ARRAY
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY, INTR_TYPE_INT },                                                  INTR_TYPE_INT_DYNAMIC_ARRAY,    2, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY },                         INTR_TYPE_INT_DYNAMIC_ARRAY,    3, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },          INTR_TYPE_INT_DYNAMIC_ARRAY,    4, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MINLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL }, INTR_TYPE_INT_DYNAMIC_ARRAY,    5, -1, LANGSPEC_F95, INTR_CLASS_T },
+
+    // MAXLOC (ARRAY [, MASK, KIND, BACK])
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "maxloc",       0,      { INTR_TYPE_INT_ARRAY },                                                                  INTR_TYPE_INT_ARRAY,    1, -3, LANGSPEC_F90, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_LOGICAL_ARRAY },                                         INTR_TYPE_INT_ARRAY,    2, -3, LANGSPEC_F90, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },                          INTR_TYPE_INT_ARRAY,    3, -3, LANGSPEC_F90, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL },       INTR_TYPE_INT_ARRAY,    4, -3, LANGSPEC_F90, INTR_CLASS_T },
+
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY },                                                             INTR_TYPE_INT_ARRAY,    1, -3, LANGSPEC_F90, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_LOGICAL_ARRAY },                                    INTR_TYPE_INT_ARRAY,    2, -3, LANGSPEC_F90, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },                     INTR_TYPE_INT_ARRAY,    3, -3, LANGSPEC_F90, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL },  INTR_TYPE_INT_ARRAY,    4, -3, LANGSPEC_F90, INTR_CLASS_T },
+
+    //// F2003 accepts CHARACTER ARRAY
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY },                                                                 INTR_TYPE_INT_ARRAY,    1, -3, LANGSPEC_F2003, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY, INTR_TYPE_LOGICAL_ARRAY },                                        INTR_TYPE_INT_ARRAY,    2, -3, LANGSPEC_F2003, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },                         INTR_TYPE_INT_ARRAY,    3, -3, LANGSPEC_F2003, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL },      INTR_TYPE_INT_ARRAY,    4, -3, LANGSPEC_F2003, INTR_CLASS_T },
+
+    // MAXLOC (ARRAY, DIM, [MASK, KIND, BACK]) (Fortran 95)
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_INT },                                                   INTR_TYPE_INT_DYNAMIC_ARRAY,    2, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY },                          INTR_TYPE_INT_DYNAMIC_ARRAY,    3, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },           INTR_TYPE_INT_DYNAMIC_ARRAY,    4, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_INT_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL },       INTR_TYPE_INT_DYNAMIC_ARRAY,    5, -1, LANGSPEC_F95, INTR_CLASS_T },
+
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_INT },                                              INTR_TYPE_INT_DYNAMIC_ARRAY,    2, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY },                     INTR_TYPE_INT_DYNAMIC_ARRAY,    3, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },      INTR_TYPE_INT_DYNAMIC_ARRAY,    4, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ALL_REAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL },  INTR_TYPE_INT_DYNAMIC_ARRAY,    5, -1, LANGSPEC_F95, INTR_CLASS_T },
+
+
+    //// F2003 accepts CHARACTER ARRAY
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY, INTR_TYPE_INT },                                                  INTR_TYPE_INT_DYNAMIC_ARRAY,    2, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY },                         INTR_TYPE_INT_DYNAMIC_ARRAY,    3, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT },          INTR_TYPE_INT_DYNAMIC_ARRAY,    4, -1, LANGSPEC_F95, INTR_CLASS_T },
+    { INTR_MAXLOC,      INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_CHAR_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL_ARRAY, INTR_TYPE_INT, INTR_TYPE_LOGICAL },       INTR_TYPE_INT_DYNAMIC_ARRAY,    5, -1, LANGSPEC_F95, INTR_CLASS_T },
+
 
 
     /* 20. Pointer association status functions */
@@ -670,6 +716,8 @@ intrinsic_entry intrinsic_table[] = {
     { INTR_SYSTEM_CLOCK,        INTR_NAME_GENERIC,      "",                     0,      { INTR_TYPE_INT },                              INTR_TYPE_NONE, 1, -6, LANGSPEC_F90, INTR_CLASS_S },
     { INTR_SYSTEM_CLOCK,        INTR_NAME_GENERIC,      "",                     0,      { INTR_TYPE_INT, INTR_TYPE_INT },               INTR_TYPE_NONE, 2, -6, LANGSPEC_F90, INTR_CLASS_S },
     { INTR_SYSTEM_CLOCK,        INTR_NAME_GENERIC,      "",                     0,      { INTR_TYPE_INT, INTR_TYPE_INT, INTR_TYPE_INT },        INTR_TYPE_NONE, 3, -6, LANGSPEC_F90, INTR_CLASS_S },
+    { INTR_SYSTEM_CLOCK,        INTR_NAME_GENERIC,      "",                     0,      { INTR_TYPE_INT, INTR_TYPE_REAL },              INTR_TYPE_NONE, 2, -6, LANGSPEC_F2003, INTR_CLASS_S },
+    { INTR_SYSTEM_CLOCK,        INTR_NAME_GENERIC,      "",                     0,      { INTR_TYPE_INT, INTR_TYPE_REAL, INTR_TYPE_INT },       INTR_TYPE_NONE, 3, -6, LANGSPEC_F2003, INTR_CLASS_S },
 
     /*
      * Fortran90 intrinsics

--- a/F-FrontEnd/src/F-intrinsics-table.c
+++ b/F-FrontEnd/src/F-intrinsics-table.c
@@ -542,6 +542,8 @@ intrinsic_entry intrinsic_table[] = {
 
     // ALLOCATED (ARRAY)
     { INTR_ALLOCATED,   INTR_NAME_GENERIC,      "allocated",    0,      { INTR_TYPE_ANY_ARRAY_ALLOCATABLE },                    INTR_TYPE_LOGICAL,      1, -6, LANGSPEC_F90, INTR_CLASS_I },
+    // ALLOCATED (SCALA) for F2003
+    { INTR_ALLOCATED,   INTR_NAME_GENERIC,      "",             0,      { INTR_TYPE_ANY },                                      INTR_TYPE_LOGICAL,      1, -6, LANGSPEC_F2003, INTR_CLASS_I },
 
     // LBOUND (ARRAY [, DIM])
     { INTR_LBOUND,      INTR_NAME_GENERIC,      "lbound",       0,      { INTR_TYPE_ANY_ARRAY },                                INTR_TYPE_INT_ARRAY,    1, -3, LANGSPEC_F90, INTR_CLASS_I },

--- a/F-FrontEnd/test/testdata/intrinsic_max.f90
+++ b/F-FrontEnd/test/testdata/intrinsic_max.f90
@@ -1,3 +1,7 @@
       program main
+        INTEGER :: i
+        CHARACTER :: s
         i = max(1,2,3,4,5)
+        s = max("a", "b", "c")
+        PRINT *, i, s
       end program main

--- a/F-FrontEnd/test/testdata/intrinsic_maxloc.f90
+++ b/F-FrontEnd/test/testdata/intrinsic_maxloc.f90
@@ -1,0 +1,56 @@
+      program test_maxloc
+        INTEGER,           DIMENSION(5,4)     :: arrayI
+        REAL,              DIMENSION(5,4)     :: arrayR
+        CHARACTER(LEN=10), DIMENSION(5,4)     :: arrayC
+
+        LOGICAL,           DIMENSION(5,4)     :: mask
+
+        INTEGER,           DIMENSION(2)       :: i0
+        REAL,              DIMENSION(2)       :: r0
+        CHARACTER(LEN=10), DIMENSION(2)       :: s0
+
+        INTEGER,           DIMENSION(4)       :: i1
+        REAL,              DIMENSION(4)       :: r1
+        CHARACTER(LEN=10), DIMENSION(4)       :: s1
+
+        ! MAXLOC(ARRAY)
+        i0 = MAXLOC(arrayI)
+        r0 = MAXLOC(arrayR)
+        s0 = MAXLOC(arrayC)
+
+        ! MAXLOC(ARRAY,MASK)
+        i0 = MAXLOC(arrayI, mask)
+        r0 = MAXLOC(arrayR, mask)
+        s0 = MAXLOC(arrayC, mask)
+
+        ! MAXLOC(ARRAY,MASK,KIND)
+        i0 = MAXLOC(arrayI, mask, 8)
+        r0 = MAXLOC(arrayR, mask, 8)
+        s0 = MAXLOC(arrayC, mask, 8)
+
+        ! MAXLOC(ARRAY,MASK,KIND,BACK)
+        i0 = MAXLOC(arrayI, mask, 8, .TRUE.)
+        r0 = MAXLOC(arrayR, mask, 8, .TRUE.)
+        s0 = MAXLOC(arrayC, mask, 8, .TRUE.)
+
+        ! MAXLOC(ARRAY,DIM)
+        i1 = MAXLOC(arrayI, 1)
+        r1 = MAXLOC(arrayR, 1)
+        s1 = MAXLOC(arrayC, 1)
+
+        ! MAXLOC(ARRAY,DIM,MASK)
+        i1 = MAXLOC(arrayI, 1, mask)
+        r1 = MAXLOC(arrayR, 1, mask)
+        s1 = MAXLOC(arrayC, 1, mask)
+
+        ! MAXLOC(ARRAY,DIM,MASK,KIND)
+        i1 = MAXLOC(arrayI, 1, mask, 8)
+        r1 = MAXLOC(arrayR, 1, mask, 8)
+        s1 = MAXLOC(arrayC, 1, mask, 8)
+
+        ! MAXLOC(ARRAY,DIM,MASK,KIND,BACK)
+        i = MAXLOC(arrayI, 0, mask, 8, .TRUE.)
+        r = MAXLOC(arrayR, 0, mask, 8, .TRUE.)
+        s = MAXLOC(arrayC, 0, mask, 8, .TRUE.)
+
+      end program test_maxloc

--- a/F-FrontEnd/test/testdata/intrinsic_maxloc.f90
+++ b/F-FrontEnd/test/testdata/intrinsic_maxloc.f90
@@ -49,8 +49,8 @@
         s1 = MAXLOC(arrayC, 1, mask, 8)
 
         ! MAXLOC(ARRAY,DIM,MASK,KIND,BACK)
-        i = MAXLOC(arrayI, 0, mask, 8, .TRUE.)
-        r = MAXLOC(arrayR, 0, mask, 8, .TRUE.)
-        s = MAXLOC(arrayC, 0, mask, 8, .TRUE.)
+        i = MAXLOC(arrayI, 1, mask, 8, .TRUE.)
+        r = MAXLOC(arrayR, 1, mask, 8, .TRUE.)
+        s = MAXLOC(arrayC, 1, mask, 8, .TRUE.)
 
       end program test_maxloc

--- a/F-FrontEnd/test/testdata/intrinsic_maxloc_2.f90
+++ b/F-FrontEnd/test/testdata/intrinsic_maxloc_2.f90
@@ -1,0 +1,16 @@
+      program test_maxloc
+        INTEGER,           DIMENSION(5,4,3)     :: array1
+        INTEGER,           DIMENSION(5)         :: array2
+
+        INTEGER                                 :: i0
+        INTEGER,           DIMENSION(4,3)       :: i1
+        INTEGER,           DIMENSION(5,3)       :: i2
+        INTEGER,           DIMENSION(5,4)       :: i3
+
+        i1 = MAXLOC(array1, 1)
+        i2 = MAXLOC(array1, 2)
+        i3 = MAXLOC(array1, 3)
+
+        i  = MAXLOC(array2, 1)
+
+      end program test_maxloc

--- a/F-FrontEnd/test/testdata/intrinsic_maxloc_3.f90
+++ b/F-FrontEnd/test/testdata/intrinsic_maxloc_3.f90
@@ -1,0 +1,5 @@
+      program test_maxloc
+        INTEGER,           DIMENSION(5,4,3)     :: array1
+        INTEGER,           DIMENSION(4,3)       :: i1
+        i1 = MAXLOC(array1, LEN("a"))
+      end program test_maxloc

--- a/F-FrontEnd/test/testdata/intrinsic_min.f90
+++ b/F-FrontEnd/test/testdata/intrinsic_min.f90
@@ -3,11 +3,14 @@
         integer(KIND=2) :: i2
         integer(KIND=4) :: i4
         integer(KIND=8) :: i8
+        character       :: s
 
         real(KIND=4)    :: r4
         double precision :: r8
 
         i = min(2,2,3,4,5)
+
+        s = min("a", "b", "c")
 
         i4 = min0(i4,i4,i4)
 


### PR DESCRIPTION
This pull request will make the follwing intrinsic procedure accept CHARACTER (scala or array) as a argument:
 - MAX
 - MIN
 - MAXLOC
 - MINLOC

And fix the retrun type of MAXLOC/MINLOC.