### PR TITLE
Type Parameter Inquiry

### DIFF
--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -11,7 +11,7 @@ static expv compile_data_args _ANSI_ARGS_((expr args));
 static expv compile_implied_do_expression _ANSI_ARGS_((expr x));
 static expv compile_dup_decl _ANSI_ARGS_((expv x));
 static expv compile_array_constructor _ANSI_ARGS_((expr x));
-static int compile_array_ref_dimension _ANSI_ARGS_((expr x, expv dims, expv subs));
+static int  compile_array_ref_dimension _ANSI_ARGS_((expr x, expv dims, expv subs));
 static expv compile_member_array_ref  _ANSI_ARGS_((expr x, expv v));
 
 struct replace_item replace_stack[MAX_REPLACE_ITEMS];

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -6243,7 +6243,7 @@ type_parameter_inquiry(expv v, expr mem)
         }
     } else if (IS_CHAR(btp)) {
         if (strcmp("kind", SYM_NAME(EXPR_SYM(mem))) == 0 ||
-            strcmp("len", SYM_NAME(EXPR_SYM(mem)))) {
+            strcmp("len", SYM_NAME(EXPR_SYM(mem))) == 0) {
             return expv_cons(F95_MEMBER_REF, type_basic(TYPE_INT), v, mem);
         }
     }

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -6308,7 +6308,12 @@ compile_member_ref(expr x)
 
     // TODO:
     //	 should work for all cases (array/substr/plain scalar).
-    if (!IS_FUNCTION_TYPE(ID_TYPE(member_id))) {
+    if (TYPE_IS_KIND(ID_TYPE(member_id)) ||
+        TYPE_IS_LEN(ID_TYPE(member_id))) {
+        /* type parameter inquiry is always scala */
+        tp = ID_TYPE(member_id);
+
+    } else if (!IS_FUNCTION_TYPE(ID_TYPE(member_id))) {
         /*
          * If type of struct_v has pointer/pointee flags on, members
          * should have those flags on too.
@@ -6333,6 +6338,7 @@ compile_member_ref(expr x)
 
         tp = retTyp;
         tp = compile_dimensions(tp, shape);
+
     } else {
         tp = ID_TYPE(member_id);
 

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -2295,6 +2295,39 @@ outx_complexPartRef(int l, expv v)
 }
 
 
+static int
+expv_is_type_parameter_inquiry(expv v)
+{
+    expv designator = EXPR_ARG1(v);
+    expv mem = EXPR_ARG2(v);
+
+    if (IS_NUMERIC(EXPV_TYPE(designator)) &&
+        strcmp("kind", SYM_NAME(EXPV_NAME(mem))) == 0) {
+        return TRUE;
+    }
+    if (IS_CHAR(EXPV_TYPE(designator)) &&
+        (strcmp("kind", SYM_NAME(EXPV_NAME(mem))) == 0 ||
+         strcmp("len", SYM_NAME(EXPV_NAME(mem))) == 0)) {
+        return TRUE;
+    }
+    return FALSE;
+}
+
+/**
+ * output FmemberRef as type parameter inquiry
+ */
+static void
+outx_type_param_inquiry(int l, expv v)
+{
+    expv designator = EXPR_ARG1(v);
+    expv mem = EXPR_ARG2(v);
+
+    EXPR_CODE(v) = FUNCTION_CALL;
+    EXPR_ARG1(v) = mem;
+    EXPR_ARG2(v) = list1(LIST, designator);
+    outx_functionCall(l, v);
+}
+
 /**
  * output FmemberRef
  */
@@ -2303,6 +2336,9 @@ outx_memberRef(int l, expv v)
 {
     expv v_left = EXPV_LEFT(v);
     expv v_right = EXPV_RIGHT(v);
+
+    if (expv_is_type_parameter_inquiry(v))
+        return outx_type_param_inquiry(l, v);
 
     if (IS_COMPLEX(EXPV_TYPE(v_left)))
         return outx_complexPartRef(l, v);

--- a/F-FrontEnd/test/testdata/type_parameter_inquiry_1.f90
+++ b/F-FrontEnd/test/testdata/type_parameter_inquiry_1.f90
@@ -1,0 +1,3 @@
+      INTEGER(KIND=4) :: i4
+      PRINT *, i4%KIND
+      END

--- a/F-FrontEnd/test/testdata/type_parameter_inquiry_2.f90
+++ b/F-FrontEnd/test/testdata/type_parameter_inquiry_2.f90
@@ -1,0 +1,3 @@
+      CHARACTER(LEN=4) :: c
+      PRINT *, c%LEN
+      END


### PR DESCRIPTION
This pull request will implement type parameter inquiry for primitive types.

ex)
```fortran
      PRINT *, i%KIND, c%LEN
```

The type parameter inquiry `KIND` and `LEN` will be transformed into an intrinsic function call.
The above code will be translated like:
```fortran
      PRINT *, KIND(i), LEN(c)
```