### PR TITLE
Implied shape

### DIFF
--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -932,6 +932,7 @@ declare_variable(ID id)
                 (!TYPE_IS_ALLOCATABLE(ID_TYPE(id))) &&
                 isSubprogram == FALSE &&
                 is_array_size_adjustable(ID_TYPE(id)) &&
+                !is_array_implicit_shape(ID_TYPE(id)) &&
                 !XMP_flag) { // For XMP, local adjustable array seems to be supported, because of LOCAL_ALIAS.
                 error("'%s' looks like a local adjustable array, "
                       "not supported yet.",

--- a/F-FrontEnd/src/F-datatype.c
+++ b/F-FrontEnd/src/F-datatype.c
@@ -565,6 +565,28 @@ is_array_shape_assumed(TYPE_DESC tp)
     return FALSE;
 }
 
+/*
+ * The array with '*' in for each upper bounds of ranks is implicit shaped array.
+ *
+ * ex)
+ *    INTEGER, PARAMETER :: array(*, 1:*) = (/(/1,2/), (/3,4/), (/5,6/)/)
+ */
+int
+is_array_implicit_shape(TYPE_DESC tp)
+{
+    assert(IS_ARRAY_TYPE(tp));
+
+    if (!TYPE_IS_PARAMETER(tp) && !IS_ARRAY_TYPE(tp))
+        return FALSE;
+
+    while(IS_ARRAY_TYPE(tp) && TYPE_REF(tp)) {
+        if (!TYPE_IS_ARRAY_ASSUMED_SIZE(tp))
+            return FALSE;
+        tp = TYPE_REF(tp);
+    }
+    return TRUE;
+}
+
 int
 is_array_size_const(TYPE_DESC tp)
 {

--- a/F-FrontEnd/src/F-datatype.c
+++ b/F-FrontEnd/src/F-datatype.c
@@ -579,11 +579,17 @@ is_array_implicit_shape(TYPE_DESC tp)
     if (!TYPE_IS_PARAMETER(tp) && !IS_ARRAY_TYPE(tp))
         return FALSE;
 
-    while(IS_ARRAY_TYPE(tp) && TYPE_REF(tp)) {
+    while (IS_ARRAY_TYPE(tp) && TYPE_REF(tp)) {
         if (!TYPE_IS_ARRAY_ASSUMED_SIZE(tp))
             return FALSE;
         tp = TYPE_REF(tp);
     }
+    if (tp == NULL || IS_ARRAY_TYPE(tp)) {
+        /* tp is corrupted! */
+        fatal("invalid array type.");
+        return FALSE;
+    }
+
     return TRUE;
 }
 

--- a/F-FrontEnd/src/F-front.h
+++ b/F-FrontEnd/src/F-front.h
@@ -1016,6 +1016,7 @@ extern void                    shrink_type(TYPE_DESC tp);
 extern TYPE_DESC               reduce_type(TYPE_DESC tp);
 
 extern int is_array_shape_assumed(TYPE_DESC tp);
+extern int is_array_implicit_shape(TYPE_DESC tp);
 //extern int is_descendant_coindexed(TYPE_DESC tp);
 extern int has_coarray_component(TYPE_DESC tp);
 

--- a/F-FrontEnd/test/testdata/implicit_shape.f08
+++ b/F-FrontEnd/test/testdata/implicit_shape.f08
@@ -1,0 +1,2 @@
+      integer,parameter :: order(0:*) = (/0,1,2,3/)
+      end


### PR DESCRIPTION
This pull request implement implicit shape.

ex)
```fortran
      INTEGER, PARAMETER, DIMENSION(1:*, *) :: array = RESHAPE((/1,2,3,4,5,6/), (/2,3/))
```