### PR TITLE
Fix #343

### DIFF
--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -2535,10 +2535,6 @@ compile_basic_type(expr x)
             } else {
                 vcharLen = vcharLen1;
                 charLen = EXPV_INT_VALUE(vcharLen1);
-                if(EXPV_CODE(vcharLen1) == INT_CONSTANT && charLen < 0) {
-                    error("length specification must be positive");
-                    return NULL;
-                }
             }
         }
     } else if(charLen == 0) {

--- a/F-FrontEnd/test/testdata/character_negative_length.f90
+++ b/F-FrontEnd/test/testdata/character_negative_length.f90
@@ -1,0 +1,5 @@
+      CHARACTER(LEN=0) :: a
+      CHARACTER(LEN=-10) :: b
+
+      PRINT *, LEN(a), LEN(b)
+      END


### PR DESCRIPTION
With this pull request, `F_Front` will accept a negative length character.

ex)
```fortran
     CHARACTER(-1) :: c
```