### PR TITLE
Fix #347

### DIFF
--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -842,6 +842,11 @@ implicit_declaration(ID id)
         return;
     }
 
+    if (tp != NULL && TYPE_IS_PROCEDURE(tp) && TYPE_REF(tp)) {
+        /* id is a procedure pointer, its type isn't determeind implicitly */
+        return;
+    }
+
     if (IS_FUNCTION_TYPE(tp)) {
         tp = FUNCTION_TYPE_RETURN_TYPE(tp);
     }
@@ -5622,42 +5627,20 @@ compile_procedure_declaration(expr x)
 
         }
 
-        if (tp != NULL) {
+        if (tp) {
             ID_TYPE(id) = procedure_type(tp);
 
         } else {
             /*
+             * `If proc-interface does not appear, the procedure declaration
+             *  statement does not specify whether the declared
+             *  procedures or procedure pointers are subroutines or functions.`
+             *
              * If proc interface is null,
-             * the function return type is declared implicitly
-             *
-             * ex)
-             *   PROCEDURE(), POINTER :: i
-             *
-             *   it will returns an INTEGER type
+             * the function return type cannot be determined.
              *
              */
-
-            if (VAR_INIT_VALUE(id)) {
-                if (IS_SUBR(EXPV_TYPE(VAR_INIT_VALUE(id)))) {
-                    ID_TYPE(id) = subroutine_type();
-                    TYPE_SET_IMPLICIT(ID_TYPE(id));
-                } else {
-                    ID_TYPE(id) = function_type(NULL);
-                    implicit_declaration(id);
-                    TYPE_SET_IMPLICIT(FUNCTION_TYPE_RETURN_TYPE(ID_TYPE(id)));
-                    TYPE_SET_IMPLICIT(ID_TYPE(id));
-                }
-                ID_TYPE(id) = procedure_type(ID_TYPE(id));
-            } else {
-                ID_TYPE(id) = function_type(NULL);
-                implicit_declaration(id);
-                TYPE_SET_IMPLICIT(FUNCTION_TYPE_RETURN_TYPE(ID_TYPE(id)));
-                TYPE_SET_IMPLICIT(ID_TYPE(id));
-                ID_TYPE(id) = procedure_type(ID_TYPE(id));
-
-                /* When the first assignment appears, fix it */
-                TYPE_SET_NOT_FIXED(ID_TYPE(id));
-            }
+            ID_TYPE(id) = procedure_type(function_type(wrap_type(type_GNUMERIC_ALL)));
         }
 
         /*

--- a/F-FrontEnd/test/testdata/procedure_pointer_with_implicit_none.f90
+++ b/F-FrontEnd/test/testdata/procedure_pointer_with_implicit_none.f90
@@ -1,0 +1,3 @@
+       IMPLICIT NONE
+       PROCEDURE(), POINTER :: pptr
+       END


### PR DESCRIPTION
This pull request will fix #347, 
and fix the procedure pointer without proc-interface.

The type of the procedure pointer without proc-interface cannot be determined even if there is implicit declaration, so regard it as a pointer to function which returns GNUMERIC_ALL.