### PR TITLE
Fix #538: Do not check intrinsic params while reading from xmod

### DIFF
--- a/F-FrontEnd/src/F-input-xmod.c
+++ b/F-FrontEnd/src/F-input-xmod.c
@@ -1093,7 +1093,7 @@ input_functionCall(xmlTextReaderPtr reader, HashTable * ht, expv * v)
     PROC_EXT_ID(id) = new_external_id_for_external_decl(s, tp);
 
     if (TYPE_IS_INTRINSIC(tp)) {
-        *v = compile_intrinsic_call(id, args);
+        *v = compile_intrinsic_call0(id, args, TRUE);
     } else {
         ID_ADDR(id) = expv_sym_term(IDENT, NULL, s);
         *v = list3(FUNCTION_CALL, ID_ADDR(id), args, expv_any_term(F_EXTFUNC, id));

--- a/F-FrontEnd/test/testdata/_issue538.f90
+++ b/F-FrontEnd/test/testdata/_issue538.f90
@@ -1,0 +1,16 @@
+MODULE issue538_mod
+
+IMPLICIT NONE
+
+CONTAINS
+
+  SUBROUTINE sub1(fill_value)
+    REAL, INTENT(IN), OPTIONAL :: fill_value
+    REAL, ALLOCATABLE :: recv_buffer(:,:)
+    INTEGER :: collector_size(10)
+    INTEGER :: nlev, global_size
+
+    ALLOCATE(recv_buffer(nlev, MERGE(global_size, SUM(collector_size(:)), PRESENT(fill_value))))
+
+  END SUBROUTINE sub1
+END MODULE issue538_mod

--- a/F-FrontEnd/test/testdata/issue538.f90
+++ b/F-FrontEnd/test/testdata/issue538.f90
@@ -1,0 +1,3 @@
+module mod1
+  use issue538_mod
+end module mod1


### PR DESCRIPTION
Fix #538 