### PR TITLE
Serveral additions for XMPT

### DIFF
--- a/libxmp/include/xmp.h
+++ b/libxmp/include/xmp.h
@@ -31,6 +31,10 @@ typedef void* xmp_desc_t;
 #include "xmp_lock.h"
 #endif
 
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
 // ----- libxmp
 extern MPI_Comm	xmp_get_mpi_comm(void);
 extern void	xmp_init_mpi(int *argc, char ***argv);
@@ -91,7 +95,7 @@ extern int      xmp_nodes_comm(xmp_desc_t d, void **comm);
 extern int      xmp_nodes_equiv(xmp_desc_t d, xmp_desc_t *dn, int lb[], int ub[], int st[]);
 extern void     xmp_sched_template_index(int* local_start_index, int* local_end_index,
 					 const int global_start_index, const int global_end_index, const int step,
-					 const xmp_desc_t template, const int template_dim);
+					 const xmp_desc_t template_arg, const int template_dim);
 extern void     xmp_sync_memory(const int* status);
 extern void     xmp_sync_all(const int* status);
 extern void     xmp_sync_image(const int image, int* status);
@@ -108,6 +112,10 @@ extern void     xmp_atomic_ref(int*, int);
 // ----- libxmp_gpu
 #ifdef _XMP_ENABLE_GPU
 extern int	xmp_get_gpu_count(void);
+#endif
+
+#ifdef  __cplusplus
+}
 #endif
 
 #endif // _XMP_USERAPI

--- a/libxmp/include/xmp_data_struct.h
+++ b/libxmp/include/xmp_data_struct.h
@@ -54,6 +54,7 @@ typedef struct _XMP_nodes_type {
 
 #ifdef _XMPT
   void *xmpt_data;
+  void *xmpt_nodes_data;
 #endif
 
   _XMP_nodes_info_t info[1];
@@ -112,6 +113,10 @@ typedef struct _XMP_template_type {
   // ----------------------------------
 
   _XMP_template_info_t info[1];
+
+#ifdef _XMPT
+  void *xmpt_template_data;
+#endif
 } _XMP_template_t;
 
 // schedule of reflect comm.
@@ -280,6 +285,9 @@ typedef struct _XMP_array_type {
 
 #ifdef _XMP_MPI3_ONESIDED
   struct xmp_coarray *coarray;
+#endif
+#ifdef _XMPT
+  void *xmpt_array_data;
 #endif
 
   _XMP_template_t *align_template;

--- a/libxmp/include/xmp_func_decl.h
+++ b/libxmp/include/xmp_func_decl.h
@@ -300,7 +300,7 @@ extern void _XMP_reduction_acc(void *data_addr, int count, int datatype, int op,
 // xmp_reflect.c
 extern void _XMP_set_reflect__(void *a, int dim, int lwidth, int uwidth, int is_periodic);
 extern void _XMP_reflect__(char *a);
-extern void _XMP_wait_async__(int async_id);
+extern void _XMP_wait_async__(int async_id, void *r_desc);
 extern void _XMP_reflect_async__(void *a, int async_id);
 
 // xmp_runtime.c

--- a/libxmp/include/xmp_internal.h
+++ b/libxmp/include/xmp_internal.h
@@ -307,7 +307,7 @@ extern void xmp_reduce_initialize();
 extern void _XMP_set_reflect__(_XMP_array_t *a, int dim, int lwidth, int uwidth,
 			       int is_periodic);
 extern void _XMP_reflect__(_XMP_array_t *a);
-extern void _XMP_wait_async__(int async_id);
+extern void _XMP_wait_async__(int async_id, void* on_desc);
 extern void _XMP_reflect_async__(_XMP_array_t *a, int async_id);
 
 // xmp_runtime.c

--- a/libxmp/include/xmp_internal.h
+++ b/libxmp/include/xmp_internal.h
@@ -307,7 +307,7 @@ extern void xmp_reduce_initialize();
 extern void _XMP_set_reflect__(_XMP_array_t *a, int dim, int lwidth, int uwidth,
 			       int is_periodic);
 extern void _XMP_reflect__(_XMP_array_t *a);
-extern void _XMP_wait_async__(int async_id, void* on_desc);
+extern void _XMP_wait_async__(int async_id, _XMP_object_ref_t* on_desc);
 extern void _XMP_reflect_async__(_XMP_array_t *a, int async_id);
 
 // xmp_runtime.c

--- a/libxmp/include/xmpt.h
+++ b/libxmp/include/xmpt.h
@@ -1,3 +1,6 @@
+#ifndef _XMP_TOOLAPI
+#define _XMP_TOOLAPI
+
 #include <limits.h>
 #include <stdint.h>
 #include "xmp_constant.h"
@@ -274,9 +277,17 @@ typedef void (*xmpt_event_sync_images_begin_t)(
 
 typedef void (*xmpt_callback_t);
 
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
 int xmpt_set_callback(xmpt_event_t, xmpt_callback_t);
 int xmpt_desc_set_data(xmp_desc_t d, xmpt_tool_data_t data);
 int xmpt_desc_get_data(xmp_desc_t d, xmpt_tool_data_t* data);
+
+#ifdef  __cplusplus
+}
+#endif
 
 extern xmpt_callback_t xmpt_callback[XMPT_EVENT_ALL+1];
 extern int xmpt_enabled;
@@ -285,4 +296,6 @@ extern xmp_desc_t on_desc;
 extern struct _xmpt_subscript_t on_subsc;
 extern xmp_desc_t from_desc;
 extern struct _xmpt_subscript_t from_subsc;
+
+#endif // _XMP_TOOLAPI
 

--- a/libxmp/include/xmpt.h
+++ b/libxmp/include/xmpt.h
@@ -275,6 +275,8 @@ typedef void (*xmpt_event_sync_images_begin_t)(
 typedef void (*xmpt_callback_t);
 
 int xmpt_set_callback(xmpt_event_t, xmpt_callback_t);
+int xmpt_desc_set_data(xmp_desc_t d, xmpt_tool_data_t data);
+int xmpt_desc_get_data(xmp_desc_t d, xmpt_tool_data_t* data);
 
 extern xmpt_callback_t xmpt_callback[XMPT_EVENT_ALL+1];
 extern int xmpt_enabled;

--- a/libxmp/include/xmpt.h
+++ b/libxmp/include/xmpt.h
@@ -292,10 +292,10 @@ int xmpt_desc_get_data(xmp_desc_t d, xmpt_tool_data_t* data);
 extern xmpt_callback_t xmpt_callback[XMPT_EVENT_ALL+1];
 extern int xmpt_enabled;
 
-extern xmp_desc_t on_desc;
+/*extern xmp_desc_t on_desc;
 extern struct _xmpt_subscript_t on_subsc;
 extern xmp_desc_t from_desc;
-extern struct _xmpt_subscript_t from_subsc;
+extern struct _xmpt_subscript_t from_subsc;*/
 
 #endif // _XMP_TOOLAPI
 

--- a/libxmp/src/xmp_align.c
+++ b/libxmp/src/xmp_align.c
@@ -44,6 +44,10 @@ void _XMP_init_array_desc(_XMP_array_t **array, _XMP_template_t *template, int d
   a->type                 = type;
   a->type_size            = type_size;
   
+#ifdef _XMPT
+  a->xmpt_array_data= NULL;
+#endif
+
   size_t dummy;
   if(type != _XMP_N_TYPE_NONBASIC)
     _XMP_setup_reduce_type(&a->mpi_type, &dummy, type);
@@ -131,6 +135,10 @@ void _XMP_init_array_desc_NOT_ALIGNED(_XMP_array_t **adesc, _XMP_template_t *tem
   a->align_comm = NULL;
   a->align_comm_size = 1;
   a->align_comm_rank = _XMP_N_INVALID_RANK;
+
+#ifdef _XMPT
+  a->xmpt_array_data = NULL;
+#endif
 
 #ifdef _XMP_MPI3_ONESIDED
   a->coarray = NULL;

--- a/libxmp/src/xmp_async.c
+++ b/libxmp/src/xmp_async.c
@@ -85,13 +85,14 @@ void xmpc_wait_async(int async_id, _XMP_object_ref_t *on_desc)
     _XMP_nodes_t *n;
     _XMP_create_task_nodes(&n, on_desc);
     if (_XMP_test_task_on_nodes(n)){
-      _XMP_wait_async__(async_id);
+      _XMP_wait_async__(async_id, on_desc);
       _XMP_end_task();
     }
     _XMP_finalize_nodes(n);
   }
   else {
-    _XMP_wait_async__(async_id);
+    
+    _XMP_wait_async__(async_id, on_desc);
   }
   
   xmpc_end_async(async_id);
@@ -102,13 +103,24 @@ void xmpc_wait_async(int async_id, _XMP_object_ref_t *on_desc)
 /* DESCRIPTION : Wait until completing asynchronous communication. */
 /* ARGUMENT    : [IN] async_id : ID of async                       */
 /*******************************************************************/
-void _XMP_wait_async__(int async_id)
+void _XMP_wait_async__(int async_id, _XMP_object_ref_t *r_desc)
 {
   _XMP_async_comm_t *async;
 
 #ifdef _XMPT
+
   xmpt_tool_data_t data = NULL;
   if (xmpt_enabled && xmpt_callback[xmpt_event_wait_async_begin]){
+    xmp_desc_t on_desc;
+    if (r_desc){
+      on_desc = r_desc->ref_kind == XMP_OBJ_REF_NODES ?
+        (xmp_desc_t)r_desc->n_desc : (xmp_desc_t)r_desc->t_desc;
+    }
+    else {
+      on_desc = (xmp_desc_t)_XMP_get_execution_nodes();
+    }
+    struct _xmpt_subscript_t on_subsc;
+    _XMPT_set_subsc(&on_subsc, r_desc);
     //    xmp_desc_t on_desc;
     //    struct _xmpt_subscript_t on_subsc;
     (*(xmpt_event_wait_async_begin_t)xmpt_callback[xmpt_event_wait_async_begin])(

--- a/libxmp/src/xmp_async.c
+++ b/libxmp/src/xmp_async.c
@@ -125,7 +125,7 @@ void _XMP_wait_async__(int async_id, _XMP_object_ref_t *r_desc)
     //    struct _xmpt_subscript_t on_subsc;
     (*(xmpt_event_wait_async_begin_t)xmpt_callback[xmpt_event_wait_async_begin])(
       (xmpt_async_id_t)async_id,
-      &on_desc,
+      on_desc,
       &on_subsc,
       &data);
   }

--- a/libxmp/src/xmp_nodes.c
+++ b/libxmp/src/xmp_nodes.c
@@ -23,7 +23,10 @@ static _XMP_nodes_t *_XMP_create_new_nodes(int is_member, int dim, int comm_size
   n->dim       = dim;
   n->comm_size = comm_size;
   n->comm      = comm;
-
+#ifdef _XMPT
+  n->xmpt_nodes_data= NULL;
+#endif
+  
   if(is_member){
     int size, rank;
     MPI_Comm_size(*((MPI_Comm *)comm), &size);

--- a/libxmp/src/xmp_runtime.c
+++ b/libxmp/src/xmp_runtime.c
@@ -40,14 +40,14 @@ void _XMP_init(int argc, char** argv)
     _XMP_initialize_async_comm_tab();
 #endif
     xmp_reduce_initialize();
+#ifdef _XMPT
+    xmpt_enabled = xmpt_initialize();
+#endif
   }
   _XMP_init_world(NULL, NULL);
   _XMP_runtime_working = _XMP_N_INT_TRUE;
   _XMP_check_reflect_type();
 
-#ifdef _XMPT
-  xmpt_enabled = xmpt_initialize();
-#endif
 
 }
 

--- a/libxmp/src/xmp_template.c
+++ b/libxmp/src/xmp_template.c
@@ -24,6 +24,10 @@ _XMP_template_t *_XMP_create_template_desc(int dim, _Bool is_fixed)
   t->onto_nodes     = NULL;
   t->chunk          = NULL;
 
+#ifdef _XMPT
+  t->xmpt_template_data = NULL;
+#endif
+
   return t;
 }
 

--- a/libxmp/src/xmpt_lib.c
+++ b/libxmp/src/xmpt_lib.c
@@ -83,10 +83,10 @@ int __attribute__((weak)) xmpt_initialize(){
   return ret;
 }
 
-xmp_desc_t on_desc;
+/*xmp_desc_t on_desc;
 struct _xmpt_subscript_t on_subsc;
 xmp_desc_t from_desc;
-struct _xmpt_subscript_t from_subsc;
+struct _xmpt_subscript_t from_subsc;*/
 
 int xmpt_set_callback(xmpt_event_t event, xmpt_callback_t callback){
 

--- a/libxmp/src/xmpt_lib.c
+++ b/libxmp/src/xmpt_lib.c
@@ -193,3 +193,26 @@ void _XMPT_set_subsc(xmpt_subscript_t subsc, _XMP_object_ref_t *desc){
     subsc->omit = 1;
   }
 }
+
+int xmpt_desc_set_data(xmp_desc_t d, void * data)
+{
+  switch(*(int*)d){
+    case _XMP_DESC_NODES: ((_XMP_nodes_t*)d)->xmpt_nodes_data = data ; break;
+    case _XMP_DESC_ARRAY: ((_XMP_array_t*)d)->xmpt_array_data = data ; break;
+    case _XMP_DESC_TEMPLATE: ((_XMP_template_t*)d)->xmpt_template_data = data ; break;
+    default: return -1;
+  }
+  return 0;
+}
+
+int xmpt_desc_get_data(xmp_desc_t d, void ** data)
+{
+  switch(*(int*)d){
+    case _XMP_DESC_NODES: *data = ((_XMP_nodes_t*)d)->xmpt_nodes_data ; break;
+    case _XMP_DESC_ARRAY: *data = ((_XMP_array_t*)d)->xmpt_array_data ; break;
+    case _XMP_DESC_TEMPLATE: *data = ((_XMP_template_t*)d)->xmpt_template_data ; break;
+    default: return -1;
+  }
+  return 0;
+}
+

--- a/libxmp/src/xmpt_lib.c
+++ b/libxmp/src/xmpt_lib.c
@@ -1,3 +1,6 @@
+/* needed when searching for other linked versions of xmpt_initialize */
+#define _GNU_SOURCE
+#include <dlfcn.h>
 #include "xmp_internal.h"
 
 xmpt_callback_t xmpt_callback[XMPT_EVENT_ALL+1] = { 0 };
@@ -45,7 +48,12 @@ int xmpt_support_level[XMPT_EVENT_ALL+1] = {
 };
 
 int __attribute__((weak)) xmpt_initialize(){
-  return 0;
+  
+  int ret = 0;
+  int (*next_tool)() = (int(*)()) dlsym(RTLD_NEXT, "xmpt_initialize");
+  if (next_tool)
+    ret = next_tool();
+  return ret;
 }
 
 xmp_desc_t on_desc;

--- a/libxmpf/include/xmpf_internal.h
+++ b/libxmpf/include/xmpf_internal.h
@@ -205,7 +205,7 @@ extern void _XMP_reflect__(_XMP_array_t *a_desc);
 extern void _XMP_reflect_async__(_XMP_array_t *a_desc, int async_id);
 
 /* From xmp_async.c */
-extern void _XMP_wait_async__(int async_id, void* on_desc);
+extern void _XMP_wait_async__(int async_id, _XMP_object_ref_t* on_desc);
 extern _XMP_async_comm_t* _XMP_get_async(int);
 extern _XMP_async_comm_t* _XMP_get_current_async();
 extern void xmpc_init_async(int);

--- a/libxmpf/include/xmpf_internal.h
+++ b/libxmpf/include/xmpf_internal.h
@@ -205,7 +205,7 @@ extern void _XMP_reflect__(_XMP_array_t *a_desc);
 extern void _XMP_reflect_async__(_XMP_array_t *a_desc, int async_id);
 
 /* From xmp_async.c */
-extern void _XMP_wait_async__(int async_id);
+extern void _XMP_wait_async__(int async_id, void* on_desc);
 extern _XMP_async_comm_t* _XMP_get_async(int);
 extern _XMP_async_comm_t* _XMP_get_current_async();
 extern void xmpc_init_async(int);

--- a/libxmpf/src/Makefile.in
+++ b/libxmpf/src/Makefile.in
@@ -44,6 +44,7 @@ IS_KCOMPUTER     = @KCOMPUTER@
 IS_FX10          = @FX10@
 IS_FX100         = @FX100@
 IS_XACC          = @XACC@
+IS_XMPT          = @XMPT@
 
 ifeq ($(IS_KCOMPUTER), $(TRUE))
         CFLAGS += -D_KCOMPUTER
@@ -58,6 +59,11 @@ endif
 ifeq ($(IS_XACC), $(TRUE))
     OBJECTS += xaccf_gcomm.o xaccf_reflect.o
     CFLAGS  += -D_XMP_XACC
+endif
+ifeq ($(IS_XMPT), $(TRUE))
+    HEADERS += $(XMP_INC_DIR)/xmpt.h
+    CFLAGS += -D_XMPT
+    FCFLAGS += -D_XMPT
 endif
 
 ifeq ($(IS_CRAY), $(TRUE))

--- a/libxmpf/src/xmpf_async.c
+++ b/libxmpf/src/xmpf_async.c
@@ -13,13 +13,13 @@ void xmpf_wait_async__(int *async_id, _XMP_object_ref_t **on_desc)
     xmpf_create_task_nodes__(&n, on_desc);
     if(xmpf_test_task_on_nodes__(&n)){
       //      _XMP_barrier_EXEC();
-      _XMP_wait_async__(*async_id);
+      _XMP_wait_async__(*async_id, on_desc);
       xmpf_end_task__();
     }
     xmpf_nodes_dealloc__(&n);
   }
   else{
-    _XMP_wait_async__(*async_id);
+    _XMP_wait_async__(*async_id, on_desc);
   }
   
   xmpc_end_async(*async_id);

--- a/libxmpf/src/xmpf_async.c
+++ b/libxmpf/src/xmpf_async.c
@@ -13,13 +13,13 @@ void xmpf_wait_async__(int *async_id, _XMP_object_ref_t **on_desc)
     xmpf_create_task_nodes__(&n, on_desc);
     if(xmpf_test_task_on_nodes__(&n)){
       //      _XMP_barrier_EXEC();
-      _XMP_wait_async__(*async_id, on_desc);
+      _XMP_wait_async__(*async_id, *on_desc);
       xmpf_end_task__();
     }
     xmpf_nodes_dealloc__(&n);
   }
   else{
-    _XMP_wait_async__(*async_id, on_desc);
+    _XMP_wait_async__(*async_id, *on_desc);
   }
   
   xmpc_end_async(*async_id);


### PR DESCRIPTION
- New functions `xmpt_desc_get_data(xmp_desc_t, xmpt_tool_data_t*)` and `xmpt_desc_set_data(xmp_desc_t, xmpt_tool_data_t)` to set and get data from a descriptor. The field is initially NULL.
- xmp.h and xmpt.h can now be included in C++ code (xmp-functions have extern "C" in that case)
- The function xmpt_initialize is only called once per tool, following the algorithm for omp_start_tool in TR6
- Fix the descriptor provided in the wait_async event