### PR TITLE
Fix #559: Do not output varDecl for tbp related ids

### DIFF
--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -4239,7 +4239,6 @@ check_final_subroutines()
                     return;
                 }
                 TBP_BINDING_ATTRS(fin) |= TYPE_BOUND_PROCEDURE_IS_FINAL;
-                VAR_INIT_VALUE(fin) = NULL; // Fix for #559
                 ID_TYPE(binding) = ID_TYPE(fin);
             }
 

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -4239,6 +4239,7 @@ check_final_subroutines()
                     return;
                 }
                 TBP_BINDING_ATTRS(fin) |= TYPE_BOUND_PROCEDURE_IS_FINAL;
+                VAR_INIT_VALUE(fin) = NULL; // Fix for #559
                 ID_TYPE(binding) = ID_TYPE(fin);
             }
 

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -5269,8 +5269,9 @@ emit_decl(int l, ID id)
                 break;
 
             case STG_EXT:
-                if (id_is_visibleVar(id) &&
-                    IS_NO_PROC_OR_DECLARED_PROC(id)) {
+                if (id_is_visibleVar(id) && IS_NO_PROC_OR_DECLARED_PROC(id) 
+                    && !TBP_BINDING_ATTRS(id)) 
+                {
                     outx_varDecl(l, id);
                 }
                 break;

--- a/F-FrontEnd/test/testdata/issue559.f90
+++ b/F-FrontEnd/test/testdata/issue559.f90
@@ -1,0 +1,37 @@
+MODULE mo_t_class
+
+  IMPLICIT NONE
+  PRIVATE
+
+  PUBLIC :: t_real2d, t_real3d, t_var
+
+  TYPE, ABSTRACT :: t_var
+    REAL, ALLOCATABLE      :: field(:,:,:,:,:)
+  END TYPE t_var
+
+  TYPE, EXTENDS(t_var) :: t_real2d
+    REAL, POINTER :: ptr(:,:) => NULL()
+  CONTAINS
+    PROCEDURE, PASS :: test => test1
+    FINAL :: finalize_real2d
+  END TYPE t_real2d
+
+  TYPE, EXTENDS(t_var) :: t_real3d
+    REAL, POINTER :: ptr(:,:,:) => NULL()
+  CONTAINS
+    FINAL :: finalize_real3d
+  END TYPE t_real3d
+
+CONTAINS
+  subroutine test1(this)
+    class(t_real2d) :: this
+  end subroutine test1
+  SUBROUTINE finalize_real2d(this)
+    TYPE(t_real2d) :: this
+  END SUBROUTINE finalize_real2d
+
+  SUBROUTINE finalize_real3d(this)
+    TYPE(t_real3d) :: this
+  END SUBROUTINE finalize_real3d
+
+END MODULE mo_t_class


### PR DESCRIPTION
#559 
@h-murai @shingo-s The problem seems to come from `VAR_INIT_VALUE` being defined somehow for the `FINAL` subroutine `ID`. This then leads to a segfault in `outx_varDecl` as it is wrongly define and make no sense. 

I didn't find where this value is set actually. So I did a quick fix in `check_final_subroutines`. If you have any idea where this might come from, I'll gladly change this fix. 