### PR TITLE
Fix #550: Keep type attribute in CLASS IS block

### DIFF
--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -1240,9 +1240,19 @@ compile_statement1(int st_no, expr x)
                 fix_array_dimensions(tp);
 
                 selector = CTL_SELECT_TYPE_ASSICIATE(CTL_PREV(ctl_top))?:CTL_SELECT_TYPE_SELECTOR(CTL_PREV(ctl_top));
+                // Get selector infor before declaring new ident.
+                ID selector_id = find_ident(EXPR_SYM(selector));
+
                 id = declare_ident(EXPR_SYM(selector), CL_VAR);
                 declare_id_type(id, tp);
 
+                // Copy back some of the saved vital selector information
+                // Fix issue #550 - Maybe all attributes should be copied
+                if(selector_id != NULL) {
+                    if(TYPE_IS_POINTER(ID_TYPE(selector_id))) {
+                        TYPE_SET_POINTER(tp);
+                    }
+                }
             } else { // NULL for CLASS DEFAULT
                 tp = NULL;
             }

--- a/F-FrontEnd/test/testdata/issue550.f90
+++ b/F-FrontEnd/test/testdata/issue550.f90
@@ -14,6 +14,7 @@ CONTAINS
     CLASS(t_state), INTENT(inout), TARGET :: this
     CLASS(t_state), POINTER, OPTIONAL :: that 
 
+    this%parent => that
 
     SELECT TYPE(that)
       CLASS IS (t_state)

--- a/F-FrontEnd/test/testdata/issue550.f90
+++ b/F-FrontEnd/test/testdata/issue550.f90
@@ -1,0 +1,24 @@
+MODULE mod1
+  IMPLICIT NONE
+  PRIVATE
+  PUBLIC :: t_state
+
+  TYPE, ABSTRACT :: t_state
+    CLASS(t_State), POINTER :: parent => NULL()
+  CONTAINS
+    PROCEDURE :: init_state
+  END TYPE t_State
+
+CONTAINS
+  SUBROUTINE init_state(this, that)
+    CLASS(t_state), INTENT(inout), TARGET :: this
+    CLASS(t_state), POINTER, OPTIONAL :: that 
+
+
+    SELECT TYPE(that)
+      CLASS IS (t_state)
+        this%parent => that
+    END SELECT
+
+  END SUBROUTINE init_state
+END MODULE mod1

--- a/F-FrontEnd/test/testdata/issue550.f90
+++ b/F-FrontEnd/test/testdata/issue550.f90
@@ -19,6 +19,8 @@ CONTAINS
     SELECT TYPE(that)
       CLASS IS (t_state)
         this%parent => that
+      CLASS DEFAULT
+        this%parent => that
     END SELECT
 
   END SUBROUTINE init_state


### PR DESCRIPTION
Fix #550 

The type is redefined in the `CLASS IS` block but I think we need to keep the attributes information as they are needed sometimes. 

