### PR TITLE
Fix #545: Imported ID should be flagged as public otherwise they are not refelected in XMOD

### DIFF
--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -5758,6 +5758,10 @@ import_module_id(ID mid,
                 SYM_NAME(use_name));
     }
 
+    if(current_module_state != M_PRIVATE) {
+        TYPE_SET_PUBLIC(ID_TYPE(id)); // Imported id should be flagged public
+    }
+
     return;
 }
 

--- a/F-FrontEnd/test/testdata/_issue545_mod1.f90
+++ b/F-FrontEnd/test/testdata/_issue545_mod1.f90
@@ -1,0 +1,8 @@
+module issue545_mod1
+  implicit none
+
+  public :: Type1
+    
+  type, abstract :: Type1
+  end type
+end module issue545_mod1

--- a/F-FrontEnd/test/testdata/_issue545_mod2.f90
+++ b/F-FrontEnd/test/testdata/_issue545_mod2.f90
@@ -1,0 +1,9 @@
+module issue545_mod2
+  use issue545_mod1, only: Type1 
+
+  implicit none
+  private
+
+  public :: Type1
+
+end module issue545_mod2

--- a/F-FrontEnd/test/testdata/_issue545_mod3.f90
+++ b/F-FrontEnd/test/testdata/_issue545_mod3.f90
@@ -1,0 +1,13 @@
+module issue545_mod3
+  use issue545_mod2, only: Type1
+
+  implicit none
+  private
+
+  public :: type2
+
+  type :: type2
+    class(Type1), pointer :: p
+  end type
+
+end module issue545_mod3

--- a/F-FrontEnd/test/testdata/issue545.f90
+++ b/F-FrontEnd/test/testdata/issue545.f90
@@ -1,0 +1,31 @@
+module issue545_mod4
+  use issue545_mod2, only: type1
+  use issue545_mod3, only: type2
+
+  implicit none 
+
+  INTEGER, PARAMETER :: n_var = 10
+
+  TYPE t_read_info
+    CLASS(type1), POINTER :: scatter_pattern
+  END TYPE
+ 
+  TYPE t_stream_id
+    TYPE(t_read_info), ALLOCATABLE :: read_info(:,:)
+  END TYPE t_stream_id
+ 
+ CONTAINS
+   SUBROUTINE read_dist_INT_2D_multivar(stream_id, location)
+ 
+     TYPE(t_stream_id), INTENT(INOUT)       :: stream_id
+     INTEGER, INTENT(IN)                    :: location
+ 
+     TYPE(type2)               :: scatter_patterns(n_var)
+     INTEGER                                :: i
+ 
+     DO i = 1, n_var
+       scatter_patterns(i)%p => stream_id%read_info(location, i)%scatter_pattern
+     END DO
+   END SUBROUTINE read_dist_INT_2D_multivar
+   
+end module issue545_mod4


### PR DESCRIPTION
Fix for issue #545 