### PR TITLE
Fix#573: Handle SPREAD intrinsic used with named arguments

### DIFF
--- a/F-FrontEnd/src/F-front.h
+++ b/F-FrontEnd/src/F-front.h
@@ -876,6 +876,7 @@ extern expr     list5 _ANSI_ARGS_((enum expr_code code, expr x1, expr x2, expr x
 extern expr     list6 _ANSI_ARGS_((enum expr_code code, expr x1, expr x2, expr x3, expr x4, expr x5, expr x6));
 
 extern expr     expr_list_get_n _ANSI_ARGS_((expr x, int n));
+extern expr     expr_list_get_n_or_named _ANSI_ARGS_((expr x, int n, const char *named_arg));
 extern int      expr_list_set_n _ANSI_ARGS_((expr x, int n, expr val, int doOverride));
 extern int      expr_list_length _ANSI_ARGS_((expr x));
 

--- a/F-FrontEnd/src/F-intrinsic.c
+++ b/F-FrontEnd/src/F-intrinsic.c
@@ -947,15 +947,15 @@ get_intrinsic_return_type(intrinsic_entry *ep, expv args, expv kindV) {
                         /* intrinsic arguments */
                         expv array, dim, ncopies;
 
-                        array = expr_list_get_n(args, 0);
+                        array = expr_list_get_n_or_named(args, 0, "array");
                         if (!(isValidTypedExpv(array))) {
                             return NULL;
                         }
-                        dim = expr_list_get_n(args, 1);
+                        dim = expr_list_get_n_or_named(args, 1, "dim");
                         if (!(isValidTypedExpv(dim))) {
                             return NULL;
                         }
-                        ncopies = expr_list_get_n(args, 2);
+                        ncopies = expr_list_get_n_or_named(args, 2, "ncopies");
                         if (!(isValidTypedExpv(ncopies))) {
                             return NULL;
                         }

--- a/F-FrontEnd/src/F-mem.c
+++ b/F-FrontEnd/src/F-mem.c
@@ -186,6 +186,36 @@ expr_list_get_n(x, n)
     return LIST_ITEM(lp);
 }
 
+expr
+expr_list_get_n_or_named(x, n, named_arg)
+     expr x;
+     int n;
+     const char* named_arg;
+{
+    list lp;
+    int i;
+
+    for (i = 0, lp = EXPR_LIST(x); (i < n && lp != NULL); i++, lp = LIST_NEXT(lp)) {};
+    if (lp == NULL) {
+        return NULL;
+    }
+    if(EXPV_KWOPT_NAME(LIST_ITEM(lp)) == NULL 
+        || strcmp(EXPV_KWOPT_NAME(LIST_ITEM(lp)), named_arg) == 0) 
+    {
+        return LIST_ITEM(lp);
+    } else {
+
+        for (i = 0, lp = EXPR_LIST(x); lp != NULL; ++i, lp = LIST_NEXT(lp)) {
+            if(LIST_ITEM(lp) != NULL) {
+                if(EXPV_KWOPT_NAME(LIST_ITEM(lp)) != NULL && strcmp(named_arg, EXPV_KWOPT_NAME(LIST_ITEM(lp))) == 0) {
+                    return LIST_ITEM(lp);
+                }
+            }
+        }
+    }
+    return NULL; //LIST_ITEM(lp);
+}
+
 int
 expr_list_set_n(x, n, val, doOverride)
      expr x;

--- a/F-FrontEnd/test/testdata/issue573.f90
+++ b/F-FrontEnd/test/testdata/issue573.f90
@@ -1,0 +1,22 @@
+module mod1
+implicit none
+integer, parameter :: wp = selected_real_kind(13,7)
+
+contains
+
+  real(wp) elemental function q_effective(qsat, fsat)
+     real(wp), intent(in) :: qsat, fsat
+     q_effective = qsat * fsat
+  end function q_effective
+
+  subroutine sub1()
+    real(wp) :: q_air_eff(10)
+    real(wp) :: q_air(10)
+    integer :: nc
+    nc = 10
+
+    q_air_eff(:) = q_effective(SPREAD(0._wp, NCOPIES=nc, DIM=1), SPREAD(1._wp, NCOPIES=nc, DIM=1))
+  end subroutine sub1
+
+end module mod1
+


### PR DESCRIPTION
Fix #573 
* Add function to get argument in list with position or name from the named argument
* Use the new function for the SPREAD instrinsic to enable the use of named arguments. 