### PR TITLE
Fix #570 & #575: Fix for Derived-type mismatch

### DIFF
--- a/F-FrontEnd/src/F-datatype.c
+++ b/F-FrontEnd/src/F-datatype.c
@@ -1790,7 +1790,7 @@ function_type_is_appliable(TYPE_DESC ftp, expv actual_args, int issue_error)
 int
 struct_type_is_compatible_for_assignment(TYPE_DESC tp1, TYPE_DESC tp2, int is_pointer_set)
 {
-    TYPE_DESC btp2;
+    TYPE_DESC btp1, btp2;
 
     assert(tp1 != NULL && TYPE_BASIC_TYPE(tp1) == TYPE_STRUCT);
 
@@ -1827,6 +1827,7 @@ struct_type_is_compatible_for_assignment(TYPE_DESC tp1, TYPE_DESC tp2, int is_po
     }
     if (debug_flag) fprintf(debug_fp," not match\n");
 
+    btp1 = getBaseParameterizedType(tp1);
     btp2 = getBaseParameterizedType(tp2);
 
     if (debug_flag) fprintf(debug_fp,"* compare type names\n");
@@ -1837,6 +1838,13 @@ struct_type_is_compatible_for_assignment(TYPE_DESC tp1, TYPE_DESC tp2, int is_po
             if (debug_flag) fprintf(debug_fp,"* compare PARENT type\n");
             return struct_type_is_compatible_for_assignment(tp1, TYPE_PARENT_TYPE(btp2), is_pointer_set);
         } else {
+            /* Check if the imported id match. Type ID might be not identical 
+             * in case of multiple indirection in module hierachy. */
+            if(btp1->imported_id && btp2->imported_id 
+                && strcmp(btp1->imported_id, btp2->imported_id) == 0) 
+            {
+                return TRUE;
+            }
             if (debug_flag) fprintf(debug_fp,"seems not compatible\n");
             return FALSE;
         }

--- a/F-FrontEnd/src/F-datatype.c
+++ b/F-FrontEnd/src/F-datatype.c
@@ -1839,7 +1839,9 @@ struct_type_is_compatible_for_assignment(TYPE_DESC tp1, TYPE_DESC tp2, int is_po
             && strcmp(btp1->imported_id, btp2->imported_id) == 0) 
         {
             return TRUE;
-        } else if (TYPE_IS_CLASS(tp1) && TYPE_PARENT(btp2) && is_pointer_set) {
+        } else if ((TYPE_IS_CLASS(tp1) || TYPE_IS_POINTER(tp1)) 
+            && TYPE_PARENT(btp2) && is_pointer_set) 
+        {
             if (debug_flag) fprintf(debug_fp,"* compare PARENT type\n");
             return struct_type_is_compatible_for_assignment(tp1, TYPE_PARENT_TYPE(btp2), is_pointer_set);
         } else {

--- a/F-FrontEnd/src/F-datatype.c
+++ b/F-FrontEnd/src/F-datatype.c
@@ -1833,18 +1833,16 @@ struct_type_is_compatible_for_assignment(TYPE_DESC tp1, TYPE_DESC tp2, int is_po
     if (debug_flag) fprintf(debug_fp,"* compare type names\n");
     if (!compare_derived_type_name(tp1, tp2)) {
         if (debug_flag) fprintf(debug_fp,"                                      ... not match\n");
-
-        if (TYPE_IS_CLASS(tp1) && TYPE_PARENT(btp2) && is_pointer_set) {
+        /* Check if the imported id match. Type ID might be not identical 
+         * in case of multiple indirection in module hierachy. */
+        if(btp1->imported_id && btp2->imported_id 
+            && strcmp(btp1->imported_id, btp2->imported_id) == 0) 
+        {
+            return TRUE;
+        } else if (TYPE_IS_CLASS(tp1) && TYPE_PARENT(btp2) && is_pointer_set) {
             if (debug_flag) fprintf(debug_fp,"* compare PARENT type\n");
             return struct_type_is_compatible_for_assignment(tp1, TYPE_PARENT_TYPE(btp2), is_pointer_set);
         } else {
-            /* Check if the imported id match. Type ID might be not identical 
-             * in case of multiple indirection in module hierachy. */
-            if(btp1->imported_id && btp2->imported_id 
-                && strcmp(btp1->imported_id, btp2->imported_id) == 0) 
-            {
-                return TRUE;
-            }
             if (debug_flag) fprintf(debug_fp,"seems not compatible\n");
             return FALSE;
         }

--- a/F-FrontEnd/src/F-datatype.h
+++ b/F-FrontEnd/src/F-datatype.h
@@ -98,6 +98,7 @@ typedef struct type_descriptor
     struct type_descriptor *ref;         /* reference to other */
     struct ident_descriptor *tagname;    /* derived type tagname */
     char is_referenced;
+    char* imported_id;         /* original imported id, if imported */
     expv kind;                 /* kind parameter */
     expv leng;                 /* len parameter */
     int size;                  /* for TYPE_CHAR char length */

--- a/F-FrontEnd/src/F-input-xmod.c
+++ b/F-FrontEnd/src/F-input-xmod.c
@@ -135,6 +135,7 @@ getTypeEntry(HashTable * ht, const char * typeId) {
             TYPE_BASIC_TYPE(tp) = TYPE_VOID;
         } else {
             e = CreateHashEntry(ht, typeId, &isNew);
+            tp->imported_id = strdup(typeId);
             SetHashValue(e, tep);
         }
     }
@@ -277,12 +278,18 @@ input_type_and_attr(xmlTextReaderPtr reader, HashTable * ht, char ** retTypeId,
 {
     char * str;
     char * typeId;
+    char * importedId;
 
     typeId = (char *) xmlTextReaderGetAttribute(reader, BAD_CAST "type");
     if (typeId == NULL)
         return FALSE;
 
     *tp = getTypeDesc(ht, typeId);
+    importedId = (char *) xmlTextReaderGetAttribute(reader, BAD_CAST "imported_id");
+    if (importedId != NULL) {
+        (*tp)->imported_id = strdup(importedId);
+        free(importedId);
+    }
 
     str = (char *) xmlTextReaderGetAttribute(reader, BAD_CAST "intent");
     if (str != NULL) {

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -802,6 +802,9 @@ outx_typeAttrs(int l, TYPE_DESC tp, const char *tag, int options)
     } else {
         outx_printi(l,"<%s type=\"%s\"", tag, getTypeID(tp));
     }
+    if(IS_STRUCT_TYPE(tp) && tp->imported_id) {
+        outx_print(" imported_id=\"%s\"", tp->imported_id);
+    }
 
     if((options & TOPT_TYPEONLY) == 0) {
 

--- a/F-FrontEnd/test/testdata/_issue575_1.f90
+++ b/F-FrontEnd/test/testdata/_issue575_1.f90
@@ -1,0 +1,17 @@
+MODULE issue575_1
+  IMPLICIT NONE
+  PRIVATE
+
+  PUBLIC :: t_model_m, t_model, t_hsm
+ 
+  TYPE, ABSTRACT :: t_hsm
+  END TYPE t_hsm
+
+  TYPE, EXTENDS(t_hsm) :: t_model
+  END TYPE t_model
+
+  TYPE t_model_m
+    TYPE(t_model), POINTER :: m
+  END TYPE t_model_m
+
+END MODULE issue575_1

--- a/F-FrontEnd/test/testdata/_issue575_2.f90
+++ b/F-FrontEnd/test/testdata/_issue575_2.f90
@@ -1,0 +1,15 @@
+MODULE issue575_2
+  USE issue575_1, ONLY: t_model, t_model_m
+
+  IMPLICIT NONE
+  PRIVATE
+
+  PUBLIC :: t_js, store
+
+  TYPE t_js
+    TYPE(t_model_m), POINTER :: models(:)
+  END TYPE t_js
+
+  TYPE(t_js) :: store
+
+END MODULE issue575_2

--- a/F-FrontEnd/test/testdata/_issue575_3.f90
+++ b/F-FrontEnd/test/testdata/_issue575_3.f90
@@ -1,0 +1,8 @@
+MODULE issue575_3
+  USE issue575_2,   ONLY: store
+
+  IMPLICIT NONE
+  PRIVATE
+
+  PUBLIC :: store
+END MODULE issue575_3

--- a/F-FrontEnd/test/testdata/issue570.f90
+++ b/F-FrontEnd/test/testdata/issue570.f90
@@ -1,0 +1,33 @@
+MODULE mod1
+
+  IMPLICIT NONE
+
+  TYPE, ABSTRACT :: t_var
+    REAL, ALLOCATABLE :: field(:,:,:,:,:)
+  END TYPE t_var
+
+  TYPE, EXTENDS(t_var) :: t_real2d
+    REAL, POINTER :: ptr(:,:) => NULL()
+  END TYPE t_real2d
+
+  TYPE t_var_p
+    CLASS(t_var), POINTER :: p
+  END TYPE t_var_p
+
+  TYPE, ABSTRACT :: t_memory
+    TYPE(t_var_p), ALLOCATABLE :: vars(:)
+  END TYPE t_memory
+
+CONTAINS
+
+  SUBROUTINE sub1(mem, var)
+
+    CLASS(t_memory), INTENT(inout)        :: mem    
+    TYPE(t_real2d), TARGET, INTENT(inout) :: var 
+    INTEGER :: pos_of_var
+
+    mem%vars(pos_of_var)%p => var
+
+  END SUBROUTINE sub1
+
+END MODULE mod1

--- a/F-FrontEnd/test/testdata/issue575.f90
+++ b/F-FrontEnd/test/testdata/issue575.f90
@@ -1,0 +1,18 @@
+MODULE mod1
+
+  USE issue575_3, ONLY: store
+  USE issue575_1, ONLY: t_model
+
+  IMPLICIT NONE
+  PRIVATE
+
+CONTAINS
+
+  SUBROUTINE sub1(model_id)
+    INTEGER, INTENT(IN) :: model_id
+    TYPE(t_model),  POINTER  :: model
+
+    model => store%models(model_id)%m
+  END SUBROUTINE sub1
+
+END MODULE mod1


### PR DESCRIPTION
Fix for issues #570 and #575 
@h-murai I have to introduce a new attribute in the `.xmod` file to track the original type id (`imported_id`). This is needed because in some cases a type can be imported twice with indirection in some other module and therefore will not have the same address but will still be the same type. With the original type id, we can control this information. 