### PR TITLE
OMPanalyzePragmaのcheckPragmaメソッドにおけるsetIfExprを呼び出すときの言語チェックの追加

### DIFF
--- a/XcodeML-Exc-Tools/src/exc/openmp/OMPanalyzePragma.java
+++ b/XcodeML-Exc-Tools/src/exc/openmp/OMPanalyzePragma.java
@@ -66,8 +66,10 @@ public class OMPanalyzePragma
 
         switch(p) {
         case TASK:
-    	info.setIfExpr(Xcons.FlogicalConstant(true));
-        info.setFinalExpr(Xcons.FlogicalConstant(false));
+            if (XmOption.isLanguageF() == true) {
+                info.setIfExpr(Xcons.FlogicalConstant(true));
+                info.setFinalExpr(Xcons.FlogicalConstant(false));
+            }
         case PARALLEL: /* new parallel section */
         case FOR: /* loop <clause_list> */
         case SECTIONS: /* sections <clause_list> */


### PR DESCRIPTION
This PR will fix https://github.com/omni-compiler/omni-compiler/issues/612